### PR TITLE
Add /publish command with AI-generated PR descriptions

### DIFF
--- a/.claude/commands/merge.md
+++ b/.claude/commands/merge.md
@@ -134,12 +134,22 @@ Output a pre-merge report:
 
 ### Step 6 — Merge into main
 
+Before merging, generate a clear PR/merge description by running:
+```
+git --no-pager log <MAIN_BRANCH>..HEAD --pretty=format:"- %s" --no-merges
+```
+Use this commit list to write a human-readable summary of all changes coming in. Group related commits into bullet points where possible. This summary goes into the merge commit message body.
+
 Execute the merge:
 
 ```
 git checkout <MAIN_BRANCH>
 git pull origin <MAIN_BRANCH>
-git merge --no-ff <FEATURE_BRANCH> -m "merge(<FEATURE_BRANCH>): merge feature into <MAIN_BRANCH>
+git merge --no-ff <FEATURE_BRANCH> -m "merge(<FEATURE_BRANCH>): <one-line feature summary>
+
+<Human-readable summary of all changes in this feature. List the key
+changes grouped by area (backend, frontend, infra, docs, etc.). This
+must accurately reflect everything coming in — not just the branch name.>
 
 Constitution gate: PASSED
 Branch: <FEATURE_BRANCH>

--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -1,0 +1,89 @@
+---
+description: Generate a meaningful PR description for the public repo sync, then run the publish pipeline (push sync branch, CI gate, merge).
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+Optional. Any text supplied is treated as additional context for the PR description (e.g. release notes, caveats, highlights to emphasize).
+
+## Outline
+
+You are a senior engineer publishing the private `origin/master` to the public repo. Your job is to write a clear, accurate PR description and then hand off to the publish script for the mechanical steps.
+
+---
+
+### Step 1 — Verify we are on master
+
+Run:
+```
+git branch --show-current
+```
+
+If not on `master`, stop and tell the user: "You must be on `master` to publish. Run: `git checkout master`"
+
+---
+
+### Step 2 — Collect the changes since last public sync
+
+Run:
+```
+git fetch public
+git --no-pager log public/master..HEAD --pretty=format:"%h %s" --no-merges
+```
+
+If there are no new commits, tell the user: "Nothing to publish — `origin/master` is already in sync with `public/master`." and stop.
+
+Read the diff summary to understand what changed:
+```
+git --no-pager diff public/master..HEAD --stat
+```
+
+---
+
+### Step 3 — Generate the PR title and description
+
+Using the commit list and diff stat from Step 2, write:
+
+**Title**: A single concise sentence (under 72 characters) that accurately summarises the most significant change(s). Do not use generic phrases like "Sync from private" or "Update master". Write something a person reading the public repo would find meaningful.
+
+**Body**: A structured markdown description with:
+- A short paragraph (2-4 sentences) summarising what this sync brings and why it matters.
+- A `## Changes` section with bullet points grouped by area (e.g. Backend, Frontend, CI, Docs, Scripts). Each bullet should be a human-readable sentence, not a raw commit subject. Omit trivial housekeeping commits (formatting, typo fixes) unless they are the only changes.
+- If `$ARGUMENTS` was supplied, incorporate that context prominently.
+
+Do NOT use em dashes in the description.
+
+---
+
+### Step 4 — Run the publish script
+
+Invoke the script with the generated title and body:
+
+```powershell
+pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/publish.ps1 `
+  -Title "<generated title>" `
+  -Body "<generated body>"
+```
+
+Stream the output so the user can see CI poll progress in real time.
+
+---
+
+### Step 5 — Report
+
+Once the script completes, output:
+
+```
+## Published
+
+- PR title: <title>
+- Public repo: <url>
+- CI: ✅ passed
+- Merged: ✅
+```
+
+If the script fails (CI failure, merge conflict, etc.), report the error clearly and tell the user what to fix before re-running `/publish`.

--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -53,6 +53,7 @@ Using the commit list and diff stat from Step 2, write:
 **Body**: A structured markdown description with:
 - A short paragraph (2-4 sentences) summarising what this sync brings and why it matters.
 - A `## Changes` section with bullet points grouped by area (e.g. Backend, Frontend, CI, Docs, Scripts). Each bullet should be a human-readable sentence, not a raw commit subject. Omit trivial housekeeping commits (formatting, typo fixes) unless they are the only changes.
+- A `## Commits` section with the raw commit log lines from Step 2 (verbatim, as a code block or bullet list), so reviewers can cross-reference exact commits.
 - If `$ARGUMENTS` was supplied, incorporate that context prominently.
 
 Do NOT use em dashes in the description.

--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -59,12 +59,18 @@ if ($existingPr) {
     Write-Step "Creating PR on $publicRepo"
     $originUrl = git remote get-url origin
     $commitMsg = git log -1 --pretty="%s"
+    # Build PR body from all commits since the last common ancestor with public/master
+    $commitLog = git --no-pager log "${PUBLIC_REMOTE}/${TARGET_BRANCH}..HEAD" --pretty=format:"- %s" --no-merges 2>$null
+    if (-not $commitLog) {
+        $commitLog = git --no-pager log -20 --pretty=format:"- %s" --no-merges
+    }
+    $prBody = "Automated sync from $originUrl master.`n`n## Changes`n`n$commitLog"
     $prUrl = gh pr create `
         --repo $publicRepo `
         --head $SYNC_BRANCH `
         --base $TARGET_BRANCH `
         --title "Sync from private: $commitMsg" `
-        --body "Automated sync from $originUrl master."
+        --body $prBody
     # Extract PR number from URL
     $prNumber = $prUrl -replace ".*/", ""
     Write-Ok "Created PR #${prNumber}: $prUrl"

--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -66,17 +66,18 @@ if ($existingPr) {
 } else {
     Write-Step "Creating PR on $publicRepo"
     $originUrl = git remote get-url origin
-    # Use AI-generated title/body if provided, otherwise fall back to commit log
+    # Always append raw commit log so reviewers can cross-reference exact commits
+    $commitLog = git --no-pager log "${PUBLIC_REMOTE}/${TARGET_BRANCH}..HEAD" --pretty=format:"- %h %s" --no-merges 2>$null
+    if (-not $commitLog) {
+        $commitLog = git --no-pager log -20 --pretty=format:"- %h %s" --no-merges
+    }
     if (-not $Title) {
         $Title = "Sync from private: $(git log -1 --pretty='%s')"
     }
     if (-not $Body) {
-        $commitLog = git --no-pager log "${PUBLIC_REMOTE}/${TARGET_BRANCH}..HEAD" --pretty=format:"- %s" --no-merges 2>$null
-        if (-not $commitLog) {
-            $commitLog = git --no-pager log -20 --pretty=format:"- %s" --no-merges
-        }
-        $Body = "Automated sync from $originUrl master.`n`n## Changes`n`n$commitLog"
+        $Body = "Automated sync from $originUrl master."
     }
+    $Body = "$Body`n`n## Commits`n`n$commitLog"
     $prUrl = gh pr create `
         --repo $publicRepo `
         --head $SYNC_BRANCH `

--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -1,12 +1,20 @@
 #!/usr/bin/env pwsh
 # publish.ps1 — Push origin/master to the public repo via a PR with CI gate.
 #
-# Usage: ./publish.ps1
+# Usage: ./scripts/publish.ps1 [-Title <string>] [-Body <string>]
+#
+# When invoked via the /publish Claude command, Title and Body are AI-generated.
+# When invoked directly, they fall back to the commit log.
 #
 # Requirements:
 #   - gh CLI authenticated (gh auth login)
 #   - 'public' remote pointing to the public repo
 #   - Must be run from origin/master
+
+param(
+    [string]$Title = "",
+    [string]$Body  = ""
+)
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
@@ -58,19 +66,23 @@ if ($existingPr) {
 } else {
     Write-Step "Creating PR on $publicRepo"
     $originUrl = git remote get-url origin
-    $commitMsg = git log -1 --pretty="%s"
-    # Build PR body from all commits since the last common ancestor with public/master
-    $commitLog = git --no-pager log "${PUBLIC_REMOTE}/${TARGET_BRANCH}..HEAD" --pretty=format:"- %s" --no-merges 2>$null
-    if (-not $commitLog) {
-        $commitLog = git --no-pager log -20 --pretty=format:"- %s" --no-merges
+    # Use AI-generated title/body if provided, otherwise fall back to commit log
+    if (-not $Title) {
+        $Title = "Sync from private: $(git log -1 --pretty='%s')"
     }
-    $prBody = "Automated sync from $originUrl master.`n`n## Changes`n`n$commitLog"
+    if (-not $Body) {
+        $commitLog = git --no-pager log "${PUBLIC_REMOTE}/${TARGET_BRANCH}..HEAD" --pretty=format:"- %s" --no-merges 2>$null
+        if (-not $commitLog) {
+            $commitLog = git --no-pager log -20 --pretty=format:"- %s" --no-merges
+        }
+        $Body = "Automated sync from $originUrl master.`n`n## Changes`n`n$commitLog"
+    }
     $prUrl = gh pr create `
         --repo $publicRepo `
         --head $SYNC_BRANCH `
         --base $TARGET_BRANCH `
-        --title "Sync from private: $commitMsg" `
-        --body $prBody
+        --title $Title `
+        --body $Body
     # Extract PR number from URL
     $prNumber = $prUrl -replace ".*/", ""
     Write-Ok "Created PR #${prNumber}: $prUrl"


### PR DESCRIPTION
This sync introduces the /publish Claude command, which generates meaningful, human-readable PR descriptions when syncing the private repo to the public mirror. Previously, the publish script produced generic 'Automated sync' text. Now Claude reads the diff, groups changes by area, and writes a proper summary before handing off to the mechanical publish pipeline.

## Changes

### Scripts
- publish.ps1 now accepts -Title and -Body parameters so the Claude command can inject AI-written descriptions. It always appends a ## Commits section with the raw commit log regardless of how it is invoked.

### Developer Tooling
- New /publish Claude command: verifies branch, collects commits since public/master, generates a structured PR description grouped by area, then calls publish.ps1 with the generated content.
- Updated /merge command: Step 6 now requires a human-readable grouped change summary in the merge commit message body.

## Commits

- 869420d feat: always include raw commit log in publish PR body - 4b6d80c feat: add /publish Claude command with AI-generated PR descriptions - af03dea docs,fix: require accurate change descriptions in merge commits and publish PRs