### PR TITLE
Add error telemetry for backend 4xx/5xx errors and fix PTY PID hijack

### DIFF
--- a/.claude/commands/clean-code.md
+++ b/.claude/commands/clean-code.md
@@ -46,12 +46,14 @@ For each exported function, class, type, interface, or constant, verify it is im
 
 Flag: any export with zero consumers.
 
-#### 2c — Unreachable code
+#### 2c — Unreachable code and silent error swallowing
 
 Look for:
 - Code after a `return`, `throw`, or `break` statement inside the same block
 - Branches whose condition is always `true` or always `false` by inspection (e.g. `if (false)`, `if (x === x)`)
-- Empty `catch` blocks that swallow errors silently
+- Empty `catch` blocks (`catch { }` or `catch (e) { }` with no body)
+- `catch` blocks that discard the error without surfacing it to the user or logging it
+- `try/finally` with no `catch` inside a React event handler (async errors in event handlers are not caught by any global boundary)
 
 Flag each occurrence with file and line number.
 
@@ -138,6 +140,7 @@ Work through every finding. For each fix:
    - **Unused import**: remove the import line (or the specific named import).
    - **Unused export**: remove the export (and the symbol if nothing in the file uses it either).
    - **Unreachable code**: delete the unreachable block.
+   - **Silent error swallowing**: add a `catch` block that either calls `setError` / shows a toast (for user-facing async operations) or logs with `console.warn` / `console.error` (for background/non-user-facing operations). Never leave the `catch` body empty.
    - **Dead file**: delete the file with `git rm`.
    - **Function too long**: extract the identified sub-operation into a named helper in the same file (or a new file if it is reusable). Update the original function to call the helper.
    - **Too many parameters**: introduce a named options interface and update the call sites.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Git Workflow
 
 - After every commit, always run `git push`.
+- **Always create branches in the current working directory.** Never `cd` into a different repo folder to create a branch. Branch off the `master` of whichever repo folder you are already working in.
 - After creating a local branch, always publish it to the remote (`git push --set-upstream origin <branch>`).
 - During implementation, commit after completing each task (use the task ID in the commit message).
 - After making any frontend changes, run `npm run build --workspace=frontend` before committing so the served build at port 7411 reflects the changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - **Add logs when the root cause is unclear.** If static analysis and code reading have not pinpointed a bug after a reasonable effort, add targeted log statements to the relevant code path, ask the user to reproduce the issue, and use the output to confirm the root cause before making any fix. Remove diagnostic logs after the bug is resolved.
 
+## Error Handling
+
+- **Never swallow errors silently.** Every `catch` block must either surface the error to the user (via `setError`, a toast, etc.) or log it (`console.warn` / `console.error` for non-user-facing errors such as WebSocket parse failures). An empty `catch` block or a `catch` that discards the error object is always a bug.
+- **`try/finally` without `catch` is acceptable only when the caller will handle the thrown error.** If the caller is a React event handler (which has no global async error boundary), the error must be caught locally.
+- **Frontend: propagate fetch/API errors to the UI.** When an API call fails, set visible error state. Do not let the mutation silently succeed (no-op) from the user's perspective.
+
 ## Project Context
 
 Argus is a tool for centrally monitoring and remotely controlling Claude Code and GitHub Copilot sessions. For full project documentation, see [README.md](README.md). For architecture, API reference, and dev setup, see [docs/README-CONTRIBUTORS.md](docs/README-CONTRIBUTORS.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Always ask before making tradeoff decisions.** If a fix or change has meaningful tradeoffs (security, performance, correctness, maintainability), stop and present the options to the user with a brief explanation of each. Do not pick one unilaterally. Examples: weakening a security check, changing a default behavior, removing a feature, choosing between approaches with different risk profiles.
 - **Only modify what the task requires.** Do not make unrelated changes in a file while fixing something else. If you spot something worth improving, raise it explicitly and get confirmation before touching it.
 
+## Debugging
+
+- **Add logs when the root cause is unclear.** If static analysis and code reading have not pinpointed a bug after a reasonable effort, add targeted log statements to the relevant code path, ask the user to reproduce the issue, and use the output to confirm the root cause before making any fix. Remove diagnostic logs after the bug is resolved.
+
 ## Project Context
 
 Argus is a tool for centrally monitoring and remotely controlling Claude Code and GitHub Copilot sessions. For full project documentation, see [README.md](README.md). For architecture, API reference, and dev setup, see [docs/README-CONTRIBUTORS.md](docs/README-CONTRIBUTORS.md).

--- a/README.md
+++ b/README.md
@@ -270,8 +270,9 @@ Argus collects anonymous usage data to help improve the product. No personal inf
 | `session_ended` | A session completes or ends |
 | `session_prompt_sent` | A prompt is dispatched to a session via Argus |
 | `session_stopped` | A session is stopped via Argus |
+| `request_error` | An HTTP request to the Argus API returns a 4xx or 5xx error |
 
-Each event includes: an anonymous installation ID (a random UUID stored in `~/.argus/telemetry-id`), the Argus version, and a timestamp. No file paths, prompts, session content, or user-identifying information are included.
+Each event includes: an anonymous installation ID (a random UUID stored in `~/.argus/telemetry-id`), the Argus version, and a timestamp. No file paths, prompts, session content, or user-identifying information are included. The `request_error` event additionally includes a sanitized error message (file paths and IDs stripped), the HTTP status code, and the origin function name.
 
 **How to disable:**
 

--- a/backend/src/api/routes/launcher.ts
+++ b/backend/src/api/routes/launcher.ts
@@ -102,7 +102,7 @@ const launcherRoutes: FastifyPluginAsync = async (fastify) => {
         // Hold the connection pending — we do NOT create a DB session here.
         // The session is created in ClaudeCodeDetector.handleHookPayload once
         // Claude fires its first hook and we learn the real session ID.
-        ptyRegistry.registerPending(msg.sessionId, socket, msg.cwd, msg.hostPid, msg.pid);
+        ptyRegistry.registerPending(msg.sessionId, socket, msg.cwd, msg.hostPid, msg.pid, msg.sessionType);
         fastify.log.info({ tempId: msg.sessionId, hostPid: msg.hostPid, pid: msg.pid, cwd: msg.cwd }, 'Launcher pending waiting for Claude hook');
         return;
       }

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -112,7 +112,8 @@ export type TelemetryEventType =
   | 'session_prompt_sent'
   | 'session_stopped'
   | 'todo_added'
-  | 'repo_diff_opened';
+  | 'repo_diff_opened'
+  | 'request_error';
 
 export const TELEMETRY_EVENT_TYPES = new Set<TelemetryEventType>([
   'app_started',
@@ -123,6 +124,7 @@ export const TELEMETRY_EVENT_TYPES = new Set<TelemetryEventType>([
   'session_stopped',
   'todo_added',
   'repo_diff_opened',
+  'request_error',
 ]);
 
 export interface TelemetryEvent {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -80,12 +80,10 @@ export async function buildServer() {
   app.setErrorHandler((error: FastifyError, request, reply) => {
     request.log.error({ err: error, requestId: request.id }, 'Request error');
     const statusCode = error.statusCode ?? 500;
-    if (statusCode >= 500) {
-      telemetryService.sendEvent('request_error', {
-        statusCode: String(statusCode),
-        errorCode: error.code ?? 'INTERNAL_ERROR',
-      });
-    }
+    telemetryService.sendEvent('request_error', {
+      statusCode: String(statusCode),
+      errorCode: error.code ?? 'INTERNAL_ERROR',
+    });
     reply.status(statusCode).send({
       error: error.code ?? 'INTERNAL_ERROR',
       message: error.message,

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -79,7 +79,14 @@ export async function buildServer() {
 
   app.setErrorHandler((error: FastifyError, request, reply) => {
     request.log.error({ err: error, requestId: request.id }, 'Request error');
-    reply.status(error.statusCode ?? 500).send({
+    const statusCode = error.statusCode ?? 500;
+    if (statusCode >= 500) {
+      telemetryService.sendEvent('request_error', {
+        statusCode: String(statusCode),
+        errorCode: error.code ?? 'INTERNAL_ERROR',
+      });
+    }
+    reply.status(statusCode).send({
       error: error.code ?? 'INTERNAL_ERROR',
       message: error.message,
       requestId: request.id,

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -32,6 +32,23 @@ const __dirname = dirname(__filename);
 
 let monitor: SessionMonitor | null = null;
 
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+const ABS_PATH_RE = /([A-Za-z]:[\\/]|\/)[^\s:)]+[\\/]([^\s:)]+)/g;
+
+function sanitizeForTelemetry(value: string): string {
+  return value
+    .replace(ABS_PATH_RE, '$2')   // keep only the filename, drop the directory prefix
+    .replace(UUID_RE, '[id]')     // replace UUIDs with [id]
+    .slice(0, 300);
+}
+
+function extractOrigin(stack: string | undefined): string {
+  if (!stack) return 'unknown';
+  // Find the first frame that is src code (not node_modules)
+  const frame = stack.split('\n').find(line => line.includes(' at ') && !line.includes('node_modules'));
+  return frame ? sanitizeForTelemetry(frame.trim()) : 'unknown';
+}
+
 export async function buildServer() {
   const config = loadConfig();
 
@@ -83,6 +100,8 @@ export async function buildServer() {
     telemetryService.sendEvent('request_error', {
       statusCode: String(statusCode),
       errorCode: error.code ?? 'INTERNAL_ERROR',
+      errorMessage: sanitizeForTelemetry(error.message),
+      errorOrigin: extractOrigin(error.stack),
     });
     reply.status(statusCode).send({
       error: error.code ?? 'INTERNAL_ERROR',

--- a/backend/src/services/claude-code-detector.ts
+++ b/backend/src/services/claude-code-detector.ts
@@ -161,7 +161,7 @@ export class ClaudeCodeDetector {
     }
 
     if (!existing) {
-      const claimed = normalizedCwd ? ptyRegistry.claimForSession(session_id, normalizedCwd) : null;
+      const claimed = normalizedCwd ? ptyRegistry.claimForSession(session_id, normalizedCwd, 'claude-code') : null;
       if (claimed) {
         return this.createPtySession(session_id, repo, claimed, now);
       }
@@ -266,7 +266,7 @@ export class ClaudeCodeDetector {
     const existingSession = getSession(sessionId);
 
     if (!existingSession) {
-      const claimed = ptyRegistry.claimForSession(sessionId, repo.path);
+      const claimed = ptyRegistry.claimForSession(sessionId, repo.path, 'claude-code');
       if (claimed) {
         logger.info(`[ClaudeDetector] session activated via PTY claim sessionId=${sessionId} hostPid=${claimed.hostPid} pid=${claimed.pid}`);
         await this.createPtySession(sessionId, repo, claimed, now);

--- a/backend/src/services/copilot-cli-detector.ts
+++ b/backend/src/services/copilot-cli-detector.ts
@@ -175,9 +175,20 @@ export class CopilotCliDetector {
       resolvedPid = existingSession!.pid;
       resolvedHostPid = existingSession!.hostPid;
       resolvedPidSource = existingSession!.pidSource;
+      // The lockfile PID is ground truth: it is written by the Copilot process itself and
+      // is always authoritative for which process owns this session. If it disagrees with the
+      // stored pid, the DB row is stale. The most likely cause is the session-type hijack bug
+      // where a Copilot scan claimed a Claude launcher's pending registry entry (keyed only by
+      // repo path) before the workspace_id message arrived, writing Claude's PID into this row.
+      // Correcting to the lockfile PID here lets the DB converge within one scan cycle.
+      if (pid !== null && pid !== existingSession!.pid) {
+        logger.warn(`[CopilotDetector] alreadyClaimed pid mismatch: lockfile=${pid} stored=${existingSession!.pid} sessionId=${sessionId} — correcting to lockfile pid`);
+        resolvedPid = pid;
+        resolvedPidSource = 'lockfile';
+      }
       if (!registryHas && isRunning) {
         logger.info(`[CopilotDetector] alreadyClaimed + WS gone + isRunning — attempting re-link sessionId=${sessionId}`);
-        const claimed = ptyRegistry.claimForSession(sessionId, repo.path);
+        const claimed = ptyRegistry.claimForSession(sessionId, repo.path, 'copilot-cli');
         if (claimed) {
           resolvedPid = claimed.pid;
           resolvedHostPid = claimed.hostPid;
@@ -198,7 +209,7 @@ export class CopilotCliDetector {
       }
     } else if (isRunning && existingSession == null) {
       logger.info(`[CopilotDetector] isRunning + not claimed — trying claimForSession sessionId=${sessionId} repoPath="${repo.path}"`);
-      const claimed = ptyRegistry.claimForSession(sessionId, repo.path);
+      const claimed = ptyRegistry.claimForSession(sessionId, repo.path, 'copilot-cli');
       if (claimed) {
         launchMode = 'pty';
         resolvedPid = claimed.pid;

--- a/backend/src/services/pty-registry.ts
+++ b/backend/src/services/pty-registry.ts
@@ -1,6 +1,7 @@
 import { normalize } from 'path';
 import WebSocket from 'ws';
 import * as logger from '../utils/logger.js';
+import type { SessionType } from '../models/index.js';
 
 function normalizePath(p: string): string {
   return normalize(p.trimEnd().replace(/[/\\]+$/, '')).toLowerCase();
@@ -17,6 +18,7 @@ interface PendingLauncher {
   ws: WebSocket;
   hostPid: number;
   pid: number | null;
+  sessionType: SessionType;
 }
 
 export class PtyRegistry {
@@ -41,10 +43,10 @@ export class PtyRegistry {
   // hostPid is the shell wrapper PID (powershell.exe on Windows, same as tool PID elsewhere).
   // pid is the initial tool PID: null on Windows (resolved later via update_pid),
   // or the same as hostPid on non-Windows (pty.pid is directly the tool process).
-  registerPending(tempId: string, ws: WebSocket, repoPath: string, hostPid: number, pid: number | null = null): void {
+  registerPending(tempId: string, ws: WebSocket, repoPath: string, hostPid: number, pid: number | null = null, sessionType: SessionType = 'claude-code'): void {
     const key = normalizePath(repoPath);
-    logger.info(`[PtyRegistry] registerPending tempId=${tempId} hostPid=${hostPid} pid=${pid} repoPath="${repoPath}" key="${key}"`);
-    this.pendingByRepoPath.set(key, { tempId, ws, hostPid, pid });
+    logger.info(`[PtyRegistry] registerPending tempId=${tempId} hostPid=${hostPid} pid=${pid} sessionType=${sessionType} repoPath="${repoPath}" key="${key}"`);
+    this.pendingByRepoPath.set(key, { tempId, ws, hostPid, pid, sessionType });
   }
 
   // Update the real tool PID for a pending connection (before claim).
@@ -78,14 +80,18 @@ export class PtyRegistry {
   // Promotes the pending connection to a claimed connection keyed by claudeSessionId.
   // Returns pid (may be null if update_pid hasn't arrived yet) and hostPid (always set),
   // or null if no launcher is waiting for this repo.
-  claimForSession(claudeSessionId: string, repoPath: string): { pid: number | null; hostPid: number } | null {
+  claimForSession(claudeSessionId: string, repoPath: string, sessionType: SessionType): { pid: number | null; hostPid: number } | null {
     const key = normalizePath(repoPath);
     const pending = this.pendingByRepoPath.get(key);
     if (!pending) {
       logger.info(`[PtyRegistry] claimForSession MISS sessionId=${claudeSessionId} repoPath="${repoPath}" key="${key}"`);
       return null;
     }
-    logger.info(`[PtyRegistry] claimForSession OK sessionId=${claudeSessionId} hostPid=${pending.hostPid} pid=${pending.pid} repoPath="${repoPath}"`);
+    if (pending.sessionType !== sessionType) {
+      logger.info(`[PtyRegistry] claimForSession TYPE MISMATCH sessionId=${claudeSessionId} expected=${sessionType} got=${pending.sessionType} repoPath="${repoPath}" — skipping`);
+      return null;
+    }
+    logger.info(`[PtyRegistry] claimForSession OK sessionId=${claudeSessionId} hostPid=${pending.hostPid} pid=${pending.pid} sessionType=${sessionType} repoPath="${repoPath}"`);
     this.connections.set(claudeSessionId, pending.ws);
     this.tempToClaimedId.set(pending.tempId, claudeSessionId);
     this.pendingByRepoPath.delete(key);

--- a/backend/tests/integration/copilot-cli-detector.test.ts
+++ b/backend/tests/integration/copilot-cli-detector.test.ts
@@ -134,7 +134,7 @@ updated_at: ${new Date().toISOString()}
     expect(session?.pid).toBeNull();
     expect(session?.hostPid).toBe(12345);
     expect(session?.pidSource).toBe('pty_registry');
-    expect(mockClaimForSession).toHaveBeenCalledWith(testSessionId, testRepoCwd);
+    expect(mockClaimForSession).toHaveBeenCalledWith(testSessionId, testRepoCwd, 'copilot-cli');
   });
 
   it('does not claim pending PTY connection for a non-running (ended) session', async () => {
@@ -189,7 +189,7 @@ updated_at: ${new Date().toISOString()}
     expect(session?.pid).toBe(22222);
     expect(session?.hostPid).toBe(20000);
     expect(session?.pidSource).toBe('pty_registry');
-    expect(mockClaimForSession).toHaveBeenCalledWith(testSessionId, testRepoCwd);
+    expect(mockClaimForSession).toHaveBeenCalledWith(testSessionId, testRepoCwd, 'copilot-cli');
   });
 
   it('skips ended+not-running session and does not re-claim (no re-claim)', async () => {
@@ -313,10 +313,12 @@ updated_at: ${new Date().toISOString()}
   });
 
   it('preserves launchMode=pty without re-claiming when alreadyClaimed=true and WS is still live', async () => {
+    mockIsPidRunning.mockReturnValueOnce(true);
+    mockPsList.mockResolvedValueOnce([{ pid: testPid, name: 'copilot', ppid: 1 }]);
     mockGetSession.mockReturnValueOnce({
       id: testSessionId,
       launchMode: 'pty',
-      pid: 33333,
+      pid: testPid,
       hostPid: 30000,
       pidSource: 'pty_registry' as const,
       status: 'active',
@@ -328,7 +330,7 @@ updated_at: ${new Date().toISOString()}
     const session = sessions.find((s) => s.id === testSessionId);
 
     expect(session?.launchMode).toBe('pty');
-    expect(session?.pid).toBe(33333);
+    expect(session?.pid).toBe(testPid);
     expect(mockClaimForSession).not.toHaveBeenCalled();
   });
 

--- a/backend/tests/launcher-ws.test.ts
+++ b/backend/tests/launcher-ws.test.ts
@@ -28,20 +28,20 @@ describe('PtyRegistry — pending / claim flow', () => {
     const mockWs = { send: vi.fn(), readyState: 1 };
     registry.registerPending('temp-uuid', mockWs as any, '/repo/path', 8348);
 
-    const claimed = registry.claimForSession('claude-session-id', '/repo/path');
+    const claimed = registry.claimForSession('claude-session-id', '/repo/path', 'claude-code');
     expect(claimed).toEqual({ pid: null, hostPid: 8348 });
     expect(registry.has('claude-session-id')).toBe(true);
   });
 
   it('claimForSession returns null when no pending launcher for that path', () => {
-    const result = registry.claimForSession('any-session', '/no/pending/here');
+    const result = registry.claimForSession('any-session', '/no/pending/here', 'claude-code');
     expect(result).toBeNull();
   });
 
   it('getClaimedId returns the claude session ID for a given temp UUID', () => {
     const mockWs = { send: vi.fn(), readyState: 1 };
     registry.registerPending('temp-1', mockWs as any, '/repo', 1234);
-    registry.claimForSession('claude-abc', '/repo');
+    registry.claimForSession('claude-abc', '/repo', 'claude-code');
     expect(registry.getClaimedId('temp-1')).toBe('claude-abc');
   });
 
@@ -55,13 +55,13 @@ describe('PtyRegistry — pending / claim flow', () => {
     const mockWs = { send: vi.fn(), readyState: 1 };
     registry.registerPending('temp-3', mockWs as any, '/repo3', 111);
     registry.unregisterPending('/repo3', 'temp-3');
-    expect(registry.claimForSession('any', '/repo3')).toBeNull();
+    expect(registry.claimForSession('any', '/repo3', 'claude-code')).toBeNull();
   });
 
   it('sendPrompt on claimed session sends to the WebSocket', async () => {
     const mockWs = { send: vi.fn(), readyState: 1 };
     registry.registerPending('temp-4', mockWs as any, '/repo4', 5678);
-    registry.claimForSession('claude-xyz', '/repo4');
+    registry.claimForSession('claude-xyz', '/repo4', 'claude-code');
 
     const p = registry.sendPrompt('claude-xyz', 'action-1', 'run tests');
     registry.handleAck('action-1', true);
@@ -74,7 +74,7 @@ describe('PtyRegistry — pending / claim flow', () => {
   it('prompt_delivered ack resolves the pending promise', async () => {
     const mockWs = { send: vi.fn(), readyState: 1 };
     registry.registerPending('t', mockWs as any, '/r', 1);
-    registry.claimForSession('s1', '/r');
+    registry.claimForSession('s1', '/r', 'claude-code');
 
     const p = registry.sendPrompt('s1', 'a1', 'hello');
     registry.handleAck('a1', true);
@@ -84,7 +84,7 @@ describe('PtyRegistry — pending / claim flow', () => {
   it('prompt_failed ack rejects the pending promise with the error message', async () => {
     const mockWs = { send: vi.fn(), readyState: 1 };
     registry.registerPending('t2', mockWs as any, '/r2', 2);
-    registry.claimForSession('s2', '/r2');
+    registry.claimForSession('s2', '/r2', 'claude-code');
 
     const p = registry.sendPrompt('s2', 'a2', 'hello');
     registry.handleAck('a2', false, 'PTY closed');
@@ -116,13 +116,13 @@ describe('PtyRegistry — pending / claim flow', () => {
     const mockWs = { send: vi.fn(), readyState: 1 };
     registry.registerPending('temp-cp3', mockWs as any, '/repo/cp3', 6666);
     registry.claimByTempId('temp-cp3', 'ws-session-3');
-    expect(registry.claimForSession('other', '/repo/cp3')).toBeNull();
+    expect(registry.claimForSession('other', '/repo/cp3', 'claude-code')).toBeNull();
   });
 
   it('unregister removes the claimed session', async () => {
     const mockWs = { send: vi.fn(), readyState: 1 };
     registry.registerPending('t3', mockWs as any, '/r3', 3);
-    registry.claimForSession('s3', '/r3');
+    registry.claimForSession('s3', '/r3', 'claude-code');
     registry.unregister('s3');
     await expect(registry.sendPrompt('s3', 'a3', 'hi')).rejects.toThrow(/not connected/i);
   });

--- a/backend/tests/pty-registry.test.ts
+++ b/backend/tests/pty-registry.test.ts
@@ -10,7 +10,7 @@ function makeMockWs() {
 function registerAndClaim(registry: PtyRegistry, claudeId: string, repoPath = '/repo', pid = 1234) {
   const ws = makeMockWs();
   registry.registerPending('temp-' + claudeId, ws as any, repoPath, pid);
-  registry.claimForSession(claudeId, repoPath);
+  registry.claimForSession(claudeId, repoPath, 'claude-code');
   return ws;
 }
 
@@ -37,13 +37,13 @@ describe('PtyRegistry', () => {
   });
 
   it('claimForSession returns null when no pending launcher exists for that path', () => {
-    expect(registry.claimForSession('any', '/no/pending')).toBeNull();
+    expect(registry.claimForSession('any', '/no/pending', 'claude-code')).toBeNull();
   });
 
   it('claimForSession returns hostPid and null pid when a pending launcher exists', () => {
     const ws = makeMockWs();
     registry.registerPending('t', ws as any, '/repo', 9999);
-    expect(registry.claimForSession('s', '/repo')).toEqual({ pid: null, hostPid: 9999 });
+    expect(registry.claimForSession('s', '/repo', 'claude-code')).toEqual({ pid: null, hostPid: 9999 });
   });
 
   it('getClaimedId returns the claude session ID after claim', () => {
@@ -61,7 +61,7 @@ describe('PtyRegistry', () => {
     const ws = makeMockWs();
     registry.registerPending('t', ws as any, '/r3', 5);
     registry.unregisterPending('/r3', 't');
-    expect(registry.claimForSession('any', '/r3')).toBeNull();
+    expect(registry.claimForSession('any', '/r3', 'claude-code')).toBeNull();
   });
 
   it('sendPrompt() sends correct JSON message on the WebSocket', async () => {
@@ -123,7 +123,7 @@ describe('PtyRegistry', () => {
     const ws = makeMockWs();
     registry.registerPending('temp-def', ws as any, '/repo3', 9999);
     registry.claimByTempId('temp-def', 'workspace-session-3');
-    expect(registry.claimForSession('other', '/repo3')).toBeNull();
+    expect(registry.claimForSession('other', '/repo3', 'claude-code')).toBeNull();
   });
 
   it('sendPrompt() rejects after timeout when no ack arrives', async () => {

--- a/docs/README-TODO-ErrorHandling.md
+++ b/docs/README-TODO-ErrorHandling.md
@@ -1,0 +1,55 @@
+# Error Handling Audit
+
+Status snapshot as of 2026-04-15. Covers `backend/src/` and `frontend/src/` only.
+
+---
+
+## Robust (surfaced to user + logged)
+
+| Area | Mechanism |
+|---|---|
+| All HTTP errors | `setErrorHandler` in `server.ts` catches every unhandled route error, fires `request_error` telemetry, returns HTTP response |
+| Process startup | `startServer().catch()` logs to stderr and exits cleanly |
+| Route: stop / interrupt / send | Explicit `try/catch` mapping domain error codes (NOT_FOUND, CONFLICT, etc.) to HTTP 404 / 409 / 422 |
+| Route: fs/scan-folder | `try/catch` with `app.log.error` and 500 response |
+| `session-controller.ts` | `try/catch` on all methods, logs failures, updates action status to `failed` |
+| `session-monitor.ts` | `try/catch` in `reconcileStaleSessions` with `logger.warn` / `logger.error` |
+| `useRepositoryManagement.ts` | All handlers surface errors via `setAddError` |
+| `LaunchDropdown` | `handleLaunch` shows error in red text below the button |
+| `SessionPromptBar` | `handleSend` / `handleInterrupt` show errors as `role="alert"` |
+| Dashboard / Session / OutputPane pages | React Query `isError` checked and displayed to user |
+
+---
+
+## Logged only (no UI feedback)
+
+| Area | Notes |
+|---|---|
+| `socket.ts` `handleMessage` | JSON parse errors: `console.warn` |
+| `socket.ts` `ws.onerror` | Closes connection but no detail logged |
+| `telemetry-service.ts` | Intentional: telemetry must never crash the app |
+
+---
+
+## Silently swallowed (not logged, not shown)
+
+| Area | Risk |
+|---|---|
+| `repository-scanner.ts` scan errors | Permission errors during folder recursion are ignored |
+| `claude-code-detector.ts` settings file errors | Hook injection failures are silently ignored |
+| `copilot-cli-detector.ts` readdir errors | Detector scan failures produce no log |
+| `pruning-job.ts` | Pruning session / output cleanup failures are completely hidden |
+| `database.ts` schema migrations | `ALTER TABLE` errors on startup have no `try/catch` |
+| `useSettings.ts` localStorage | Read and write failures are silent; app falls back to defaults |
+| `onboardingStorage.ts` | Intentional: tour continues in-memory if storage is unavailable |
+| `api.ts` `postTelemetryEvent` | Intentional fire-and-forget (`.catch(() => {})`) |
+| `TodoPanel` mutation `onError` | Removes item from pending set but shows no error to the user |
+
+---
+
+## Critical gaps to address
+
+1. **Pruning job failures**: Expired sessions and outputs may not be cleaned up, with no indication to the operator.
+2. **Database schema migration errors**: `ALTER TABLE` commands on startup have no error handling. A failure could leave the DB in a broken state.
+3. **File-watcher silent failures**: `repository-scanner`, `copilot-cli-detector`, and `claude-code-detector` all swallow I/O errors. These could explain why sessions are not detected without any trace in the logs.
+4. **localStorage settings**: Users silently lose settings on storage quota or security errors with no warning.

--- a/frontend/src/components/LaunchDropdown/LaunchDropdown.tsx
+++ b/frontend/src/components/LaunchDropdown/LaunchDropdown.tsx
@@ -12,6 +12,7 @@ interface Props {
 export default function LaunchDropdown({ repoPath }: Props) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState<'claude' | 'copilot' | null>(null);
+  const [launchError, setLaunchError] = useState<string | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
   const { data: tools } = useQuery({
@@ -63,18 +64,25 @@ export default function LaunchDropdown({ repoPath }: Props) {
 
   const handleLaunch = async (tool: 'claude' | 'copilot') => {
     setOpen(false);
-    await launchInTerminal(tool, repoPath);
+    try {
+      await launchInTerminal(tool, repoPath);
+    } catch (err) {
+      setLaunchError(err instanceof Error ? err.message : 'Failed to launch');
+    }
   };
 
   const hasAny = tools?.claude || tools?.copilot;
 
   return (
     <div className="relative" ref={menuRef}>
+      {launchError && (
+        <p className="text-xs text-red-600 mb-1">{launchError}</p>
+      )}
       <Button
         variant="outline"
         size="sm"
         data-tour-id="dashboard-launch"
-        onClick={() => setOpen(o => !o)}
+        onClick={() => { setLaunchError(null); setOpen(o => !o); }}
         title="Launch a new session with Argus"
         aria-label="Launch with Argus"
         aria-expanded={open}

--- a/frontend/src/hooks/useRepositoryManagement.ts
+++ b/frontend/src/hooks/useRepositoryManagement.ts
@@ -93,6 +93,9 @@ export function useRepositoryManagement(): RepositoryManagement {
     try {
       await removeRepository(id);
       queryClient.setQueryData<Repository[]>(['repositories'], (old = []) => old.filter(r => r.id !== id));
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Failed to remove repository';
+      setAddError(msg);
     } finally {
       setRemoving(false);
       setRemoveConfirmId(null);

--- a/frontend/src/services/socket.ts
+++ b/frontend/src/services/socket.ts
@@ -25,8 +25,8 @@ function handleMessage(event: MessageEvent): void {
     if (allHandlers) {
       allHandlers.forEach((h) => h(msg));
     }
-  } catch {
-    // ignore parse errors
+  } catch (err) {
+    console.warn('[socket] Failed to parse WebSocket message', err);
   }
 }
 


### PR DESCRIPTION
Automated sync from https://github.com/aarthi-ntrjn/argus-private.git master.

## Commits

- e5ae75d fix: prevent cross-session-type PID hijack in PTY registry - 3244a7c fix(merge-gate): add request_error telemetry event to README - 50818a0 docs: add error handling audit to docs - e7c201b fix: surface swallowed errors in frontend and update error-handling rules - 9dc2654 feat: include sanitized error message and origin in request_error telemetry - 06f29ec feat: include 4xx errors in request_error telemetry - 700c872 feat: send telemetry on backend 5xx errors - 9453a9d docs: always create branches in the current working directory - 5e1eff7 docs: add Debugging section to CLAUDE.md