### PR TITLE
Switch npm landing page badges to live shields.io URLs

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -216,7 +216,7 @@
       </a>
       <a href="https://www.npmjs.com/package/argus-ai-hub" target="_blank" rel="noopener noreferrer">
         <img
-          src="https://img.shields.io/badge/Weekly%20Downloads-coming%20soon-3b82f6?style=for-the-badge&logo=npm&logoColor=white&labelColor=1e40af"
+          src="https://img.shields.io/npm/dw/argus-ai-hub?style=for-the-badge&logo=npm&logoColor=white&label=Weekly%20Downloads&labelColor=1e40af&color=3b82f6"
           alt="Weekly Downloads"
           loading="lazy"
           class="badge"
@@ -224,7 +224,7 @@
       </a>
       <a href="https://www.npmjs.com/package/argus-ai-hub" target="_blank" rel="noopener noreferrer">
         <img
-          src="https://img.shields.io/badge/npm-coming%20soon-3b82f6?style=for-the-badge&logo=npm&logoColor=white&labelColor=1e40af"
+          src="https://img.shields.io/npm/v/argus-ai-hub?style=for-the-badge&logo=npm&logoColor=white&label=npm&labelColor=1e40af&color=3b82f6"
           alt="npm version"
           loading="lazy"
           class="badge"


### PR DESCRIPTION
Now that rgus-ai-hub is published to npm, this sync replaces the static 'coming soon' placeholder badges on the landing page with live dynamic badges. Visitors will now see the real package version and weekly download count directly on the landing page.

## Changes

### Landing Page
- Weekly Downloads badge now pulls live data from /npm/dw/argus-ai-hub
- Version badge now pulls live data from /npm/v/argus-ai-hub
- Both badges retain the existing blue color scheme and or-the-badge style

## Commits

- 3452c5e feat: switch npm badges to dynamic shields.io URLs

## Commits

- 3452c5e feat: switch npm badges to dynamic shields.io URLs