### PR TITLE
Add GitHub Pages deploy workflow for landing page

### DIFF
--- a/.github/supply-chain/action-shas.md
+++ b/.github/supply-chain/action-shas.md
@@ -6,6 +6,9 @@ Resolved via `git ls-remote` on 2026-04-03. Re-resolve when bumping action versi
 actions/checkout@v4.3.1    = 34e114876b0b11c390a56381ad16ebd13914f8d5
 actions/setup-node@v4.4.0  = 49933ea5288caeca8642d1e84afbd3f7d6820020
 actions/dependency-review-action@v4.9.0 = 2031cfc080254a8a887f58cffee85186f0e49e48
+actions/configure-pages@v5.0.0 = 983d7736d9b0ae728b81ab479565c72886d7745b
+actions/upload-pages-artifact@v3.0.1 = 56afc609e74202658d3ffba0e8f6dda462b719fa
+actions/deploy-pages@v4.0.5 = d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
 ```
 
 ## How to re-resolve

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -1,0 +1,41 @@
+# Purpose: Deploy /landing to GitHub Pages on every push to master
+#          when files under landing/ change.
+
+name: Deploy Landing Page
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'landing/**'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './landing'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -26,16 +26,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: './landing'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
This sync adds the GitHub Pages deployment workflow to the public repo. Once GitHub Pages is enabled (Settings > Pages > Source: GitHub Actions), every push to master that touches landing/** will automatically deploy the landing page.

## Changes

### CI
- Added .github/workflows/deploy-landing.yml to deploy the landing/ directory to GitHub Pages on every push to master when landing files change

## Commits

- 1a03a3f ci: add GitHub Pages deploy workflow for landing page

## Commits

- 1a03a3f ci: add GitHub Pages deploy workflow for landing page