### PR TITLE
Sync from private: fix: add missing dotenv dependency to published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argus-ai-hub",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Your command center for Claude Code and GitHub Copilot CLI sessions. Watch every session live, send commands, and stop runaway agents, all from a single browser tab.",
   "license": "MIT",
   "homepage": "https://github.com/aarthi-ntrjn/argus#readme",
@@ -59,6 +59,7 @@
     "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
     "better-sqlite3": "12.8.0",
     "chokidar": "3.6.0",
+    "dotenv": "^17.4.2",
     "fastify": "5.8.4",
     "js-yaml": "4.1.1",
     "node-pty": "^1.1.0",


### PR DESCRIPTION
Automated sync from https://github.com/aarthi-ntrjn/argus-private.git master.

## Commits

- f46d1b7 fix: add missing dotenv dependency to published package