### PR TITLE
Sync from private: fix: add argus-ai-hub bin entry so npx argus-ai-hub works

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argus-ai-hub",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Your command center for Claude Code and GitHub Copilot CLI sessions. Watch every session live, send commands, and stop runaway agents, all from a single browser tab.",
   "license": "MIT",
   "homepage": "https://github.com/aarthi-ntrjn/argus#readme",
@@ -12,7 +12,8 @@
   },
   "type": "module",
   "bin": {
-    "argus": "./bin/argus.js"
+    "argus": "./bin/argus.js",
+    "argus-ai-hub": "./bin/argus.js"
   },
   "directories": {
     "doc": "docs",


### PR DESCRIPTION
Automated sync from https://github.com/aarthi-ntrjn/argus-private.git master.

## Commits

- 745e756 fix: add argus-ai-hub bin entry so npx argus-ai-hub works