### PR TITLE
Sync from private: fix: call compiled launch.js directly instead of npm --workspace

### DIFF
--- a/backend/src/api/routes/tools.ts
+++ b/backend/src/api/routes/tools.ts
@@ -23,12 +23,12 @@ const YOLO_FLAGS: Record<ToolCommand, string> = {
 
 // Base command (no --cwd): safe to copy and run manually from any directory.
 function buildLaunchCmdBase(tool: ToolCommand, yoloMode = false): string {
-  const base = `npm --prefix "${ARGUS_ROOT}" run launch --workspace=backend -- ${tool}`;
+  const launchScript = path.join(ARGUS_ROOT, 'backend', 'dist', 'cli', 'launch.js');
+  const base = `node "${launchScript}" ${tool}`;
   return yoloMode ? `${base} ${YOLO_FLAGS[tool]}` : base;
 }
 
 // Full command with --cwd baked in: used when the backend spawns the terminal.
-// npm --workspace changes cwd to the workspace root, so we must pass --cwd explicitly.
 function buildLaunchCmdWithCwd(tool: ToolCommand, repoPath: string, yoloMode = false): string {
   return `${buildLaunchCmdBase(tool, yoloMode)} --cwd "${repoPath}"`;
 }

--- a/backend/src/cli/launch.ts
+++ b/backend/src/cli/launch.ts
@@ -19,8 +19,6 @@ function log(msg: string) {
 process.stderr.write(`[launch] log: ${logFile}\n`);
 
 // Parse --cwd <path> out of argv before passing the rest to resolveLaunchCommand.
-// This is needed because npm --workspace changes cwd to the workspace root, so we
-// cannot rely on process.cwd() to know which repo the user wants to work in.
 const rawArgs = process.argv.slice(2);
 let cwd = process.cwd();
 const toolArgs: string[] = [];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argus-ai-hub",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Your command center for Claude Code and GitHub Copilot CLI sessions. Watch every session live, send commands, and stop runaway agents, all from a single browser tab.",
   "license": "MIT",
   "homepage": "https://github.com/aarthi-ntrjn/argus#readme",


### PR DESCRIPTION
Automated sync from https://github.com/aarthi-ntrjn/argus-private.git master.

## Commits

- d5295fa fix: call compiled launch.js directly instead of npm --workspace