### PR TITLE
Fix Linux/Codespaces terminal launch and add --version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,3 +293,29 @@ Each event includes: an anonymous installation ID (a random UUID stored in `~/.a
 ## For Contributors
 
 See [docs/README-CONTRIBUTORS.md](docs/README-CONTRIBUTORS.md) for architecture, dev setup, API reference, security model, CI pipeline, and development guides.
+
+## Uninstall and Cleanup
+
+### Remove the package
+
+If you installed Argus globally via npm:
+
+```bash
+npm uninstall -g argus-ai-hub
+```
+
+If you only ever ran Argus with `npx`, no persistent package is installed. You can optionally clear the npx cache:
+
+```bash
+npx clear-npx-cache
+```
+
+### Remove Argus data
+
+Argus stores all its data under `~/.argus/`. To delete it completely:
+
+```bash
+rm -rf ~/.argus
+```
+
+This removes the SQLite database, config file, and telemetry ID. After this, a fresh run will start with default settings.

--- a/backend/src/api/routes/tools.ts
+++ b/backend/src/api/routes/tools.ts
@@ -43,28 +43,53 @@ function isCopilotInstalled(): boolean {
   return isInstalled(ToolCommands.COPILOT);
 }
 
+function spawnDetached(file: string, args: string[]): void {
+  const child = spawn(file, args, { detached: true, stdio: 'ignore' });
+  child.on('error', (err) => {
+    logger.warn(`[LaunchTerminal] spawn ${file} failed: ${err.message}`);
+  });
+  child.unref();
+}
+
 function openTerminalWithCommand(cmd: string): void {
   logger.info(`[LaunchTerminal] opening terminal with command: ${cmd}`);
-  if (platform() === 'win32') {
+  const os = platform();
+
+  if (os === 'win32') {
     // Prefer Windows Terminal; fall back to a plain PowerShell window.
     const wtAvailable = spawnSync('where', ['wt.exe'], { encoding: 'utf-8', timeout: 2000 }).status === 0;
     if (wtAvailable) {
-      // wt.exe new-tab opens a new tab running PowerShell with the launch command.
-      spawn('wt.exe', ['new-tab', '--', 'powershell', '-NoExit', '-Command', cmd], {
-        detached: true, stdio: 'ignore',
-      }).unref();
+      spawnDetached('wt.exe', ['new-tab', '--', 'powershell', '-NoExit', '-Command', cmd]);
     } else {
-      spawn('cmd.exe', ['/c', 'start', 'powershell', '-NoExit', '-Command', cmd], {
-        detached: true, stdio: 'ignore', shell: false,
-      }).unref();
+      spawnDetached('cmd.exe', ['/c', 'start', 'powershell', '-NoExit', '-Command', cmd]);
     }
-  } else {
-    // macOS: open a new Terminal window running the command.
-    // Escape double-quotes inside the AppleScript string literal.
+    return;
+  }
+
+  if (os === 'darwin') {
+    // macOS: open a new Terminal window via AppleScript.
     const escaped = cmd.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
     const script = `tell application "Terminal"\n  do script "${escaped}"\n  activate\nend tell`;
-    spawn('osascript', ['-e', script], { detached: true, stdio: 'ignore' }).unref();
+    spawnDetached('osascript', ['-e', script]);
+    return;
   }
+
+  // Linux: try common terminal emulators in order of preference.
+  const terminals = [
+    { bin: 'x-terminal-emulator', args: ['-e', cmd] },
+    { bin: 'gnome-terminal',      args: ['--', 'bash', '-c', `${cmd}; exec bash`] },
+    { bin: 'xterm',               args: ['-e', cmd] },
+    { bin: 'konsole',             args: ['--noclose', '-e', cmd] },
+  ];
+  for (const t of terminals) {
+    if (spawnSync('which', [t.bin], { encoding: 'utf-8', timeout: 2000 }).status === 0) {
+      spawnDetached(t.bin, t.args);
+      return;
+    }
+  }
+
+  // No GUI terminal found (e.g. headless / Codespaces).
+  throw new Error(`No GUI terminal emulator found. Run this command manually in your terminal:\n${cmd}`);
 }
 
 const toolsRoutes: FastifyPluginAsync = async (app) => {
@@ -100,8 +125,14 @@ const toolsRoutes: FastifyPluginAsync = async (app) => {
       const cmd = repoPath
         ? buildLaunchCmdWithCwd(tool, repoPath, yoloMode)
         : buildLaunchCmdBase(tool, yoloMode);
-      openTerminalWithCommand(cmd);
-      return reply.status(202).send({ status: 'launched' });
+      try {
+        openTerminalWithCommand(cmd);
+        return reply.status(202).send({ status: 'launched' });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.warn(`[LaunchTerminal] ${message}`);
+        return reply.status(422).send({ status: 'no-terminal', message, cmd });
+      }
     }
   );
 };

--- a/bin/argus.js
+++ b/bin/argus.js
@@ -1,5 +1,16 @@
 #!/usr/bin/env node
 
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { version } = require('../package.json');
+
+const args = process.argv.slice(2);
+if (args.includes('--version') || args.includes('-v')) {
+  console.log(version);
+  process.exit(0);
+}
+
 import { startServer } from '../backend/dist/server.js';
 
 startServer().catch((err) => {

--- a/frontend/src/components/LaunchDropdown/LaunchDropdown.tsx
+++ b/frontend/src/components/LaunchDropdown/LaunchDropdown.tsx
@@ -13,6 +13,8 @@ export default function LaunchDropdown({ repoPath }: Props) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState<'claude' | 'copilot' | null>(null);
   const [launchError, setLaunchError] = useState<string | null>(null);
+  const [noTerminalCmd, setNoTerminalCmd] = useState<string | null>(null);
+  const [cmdCopied, setCmdCopied] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
   const { data: tools } = useQuery({
@@ -65,10 +67,29 @@ export default function LaunchDropdown({ repoPath }: Props) {
   const handleLaunch = async (tool: 'claude' | 'copilot') => {
     setOpen(false);
     try {
-      await launchInTerminal(tool, repoPath);
+      const { cmd } = await launchInTerminal(tool, repoPath);
+      if (cmd) setNoTerminalCmd(cmd);
     } catch (err) {
       setLaunchError(err instanceof Error ? err.message : 'Failed to launch');
     }
+  };
+
+  const handleCopyCmd = async () => {
+    if (!noTerminalCmd) return;
+    try {
+      await navigator.clipboard.writeText(noTerminalCmd);
+    } catch {
+      const el = document.createElement('textarea');
+      el.value = noTerminalCmd;
+      el.style.position = 'fixed';
+      el.style.opacity = '0';
+      document.body.appendChild(el);
+      el.select();
+      document.execCommand('copy');
+      document.body.removeChild(el);
+    }
+    setCmdCopied(true);
+    setTimeout(() => setCmdCopied(false), 1500);
   };
 
   const hasAny = tools?.claude || tools?.copilot;
@@ -78,11 +99,27 @@ export default function LaunchDropdown({ repoPath }: Props) {
       {launchError && (
         <p className="text-xs text-red-600 mb-1">{launchError}</p>
       )}
+      {noTerminalCmd && (
+        <div className="mb-1 p-2 bg-gray-50 border border-gray-200 rounded text-xs">
+          <p className="text-gray-600 mb-1">No terminal available. Run manually:</p>
+          <div className="flex items-start gap-1">
+            <code className="flex-1 break-all text-gray-800 font-mono text-[10px] leading-relaxed">{noTerminalCmd}</code>
+            <button
+              onClick={handleCopyCmd}
+              className="icon-btn shrink-0 text-gray-500 hover:text-gray-700"
+              aria-label="Copy command"
+              title="Copy command"
+            >
+              {cmdCopied ? <span className="text-green-600">✓</span> : <Copy size={11} aria-hidden="true" />}
+            </button>
+          </div>
+        </div>
+      )}
       <Button
         variant="outline"
         size="sm"
         data-tour-id="dashboard-launch"
-        onClick={() => { setLaunchError(null); setOpen(o => !o); }}
+        onClick={() => { setLaunchError(null); setNoTerminalCmd(null); setOpen(o => !o); }}
         title="Launch a new session with Argus"
         aria-label="Launch with Argus"
         aria-expanded={open}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -121,11 +121,23 @@ export async function getAvailableTools(): Promise<AvailableTools> {
   return apiFetch<AvailableTools>('/tools');
 }
 
-export async function launchInTerminal(tool: ToolCommand, repoPath?: string): Promise<void> {
-  await apiFetch<void>('/sessions/launch-terminal', {
+// Returns { cmd } when the server cannot open a terminal (headless/Codespaces),
+// so the caller can show the command for manual execution. Throws on other errors.
+export async function launchInTerminal(tool: ToolCommand, repoPath?: string): Promise<{ cmd?: string }> {
+  const res = await fetch(`${BASE}/sessions/launch-terminal`, {
     method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ tool, repoPath }),
   });
+  if (res.status === 202) return {};
+  if (res.status === 422) {
+    const body = await res.json() as { cmd?: string };
+    return { cmd: body.cmd };
+  }
+  const text = await res.text();
+  let message = text;
+  try { message = (JSON.parse(text) as { message?: string }).message ?? text; } catch { /* use raw text */ }
+  throw new Error(message);
 }
 
 export async function getArgusSettings(): Promise<ArgusConfig> {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argus-ai-hub",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Your command center for Claude Code and GitHub Copilot CLI sessions. Watch every session live, send commands, and stop runaway agents, all from a single browser tab.",
   "license": "MIT",
   "homepage": "https://github.com/aarthi-ntrjn/argus#readme",


### PR DESCRIPTION
This sync brings Linux and Codespaces compatibility to the "Launch with Argus" feature, which previously crashed the server on non-macOS platforms. The backend now detects the OS and tries common Linux terminal emulators in order, returning a graceful 422 with the raw command when running headless (e.g. Codespaces). The frontend shows that command inline with a one-click copy button so users can always launch manually.

## Changes

**Backend**
- Split terminal launch logic per OS: Windows (wt.exe/cmd.exe), macOS (osascript), Linux (x-terminal-emulator, gnome-terminal, xterm, konsole)
- Return HTTP 422 with the launch command when no GUI terminal is available (headless/Codespaces), instead of crashing
- All spawn errors are now logged rather than swallowed

**Frontend**
- Show an inline panel with the launch command and a copy button when the server returns 422 (no terminal available)
- launchInTerminal API function now handles 202 (launched) and 422 (no terminal) explicitly, throwing only on unexpected errors

**CLI**
- Added --version / -v flag to argus / argus-ai-hub bin entry

**Docs**
- Added Uninstall and Cleanup section to README

## Commits

```
a862ce7 fix: show manual command when no terminal available (headless/Codespaces)
bb5d57b fix: handle Linux terminals and prevent server crash on launch
f700931 chore: bump version to 0.1.4
a740f93 feat: add --version / -v flag to bin/argus.js
a7488cc docs: add Uninstall and Cleanup section to README
```

## Commits

- a862ce7 fix: show manual command when no terminal available (headless/Codespaces) - bb5d57b fix: handle Linux terminals and prevent server crash on launch - f700931 chore: bump version to 0.1.4 - a740f93 feat: add --version / -v flag to bin/argus.js - a7488cc docs: add Uninstall and Cleanup section to README