### PR TITLE
Guard /publish and /publish-npm against accidental invocation

### DIFF
--- a/.claude/commands/publish-npm.md
+++ b/.claude/commands/publish-npm.md
@@ -2,9 +2,35 @@
 description: Tag the current version, push to both remotes, and monitor the npm publish workflow on the public repo until it succeeds or fails.
 ---
 
+## Invocation rules
+
+**ONLY execute this skill when the user explicitly types `/publish-npm` as a standalone command.**
+Do NOT execute it in response to any of the following:
+- Phrases like "publish npm", "release the package", "push to npm", or any paraphrase
+- Being asked to "run the next step" when an npm release is implied
+- Any autonomous or inferred intent — the user must type the exact slash command `/publish-npm`
+
+If this skill was not triggered by the exact command `/publish-npm`, stop immediately without taking any action.
+
+---
+
 ## Outline
 
 You are releasing the npm package for this project. Follow these steps exactly.
+
+---
+
+### Step 0 — Verify we are on master
+
+Run:
+```
+git branch --show-current
+```
+
+If not on `master`, **stop immediately** and tell the user:
+"This skill must be run from `master`. You are currently on `<branch>`. Run: `git checkout master` first."
+
+Do not proceed past this step unless the branch is exactly `master`.
 
 ---
 

--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -2,6 +2,18 @@
 description: Generate a meaningful PR description for the public repo sync, then run the publish pipeline (push sync branch, CI gate, merge).
 ---
 
+## Invocation rules
+
+**ONLY execute this skill when the user explicitly types `/publish` as a standalone command.**
+Do NOT execute it in response to any of the following:
+- Phrases like "publish", "sync the public repo", "push to public", or any paraphrase
+- Being asked to "run the next step" when publish is implied
+- Any autonomous or inferred intent — the user must type the exact slash command `/publish`
+
+If this skill was not triggered by the exact command `/publish`, stop immediately without taking any action.
+
+---
+
 ## User Input
 
 ```text
@@ -23,7 +35,10 @@ Run:
 git branch --show-current
 ```
 
-If not on `master`, stop and tell the user: "You must be on `master` to publish. Run: `git checkout master`"
+If not on `master`, **stop immediately** and tell the user:
+"This skill must be run from `master`. You are currently on `<branch>`. Run: `git checkout master` first."
+
+Do not proceed past this step unless the branch is exactly `master`.
 
 ---
 


### PR DESCRIPTION
Both Claude skills now enforce two hard stops: they must be triggered by the exact slash command (not a paraphrase or implied next step), and the current branch must be master before any action is taken. This prevents accidental public repo pushes or npm releases from feature branches or inferred automation.

## Changes

**Claude Skills**
- Added invocation guard to /publish: only runs when user types the exact command /publish; stops with a clear message if not on master
- Added invocation guard to /publish-npm: same rules, plus an explicit Step 0 branch check before tagging

## Commits

```
19d34c8 chore: guard /publish and /publish-npm against accidental invocation
```

## Commits

- 19d34c8 chore: guard /publish and /publish-npm against accidental invocation