### PR TITLE
Prompt history navigation, dashboard layout fixes, and version in Settings

### DIFF
--- a/.claude/commands/publish-npm.md
+++ b/.claude/commands/publish-npm.md
@@ -34,7 +34,21 @@ Do not proceed past this step unless the branch is exactly `master`.
 
 ---
 
-### Step 1 — Run the publish-npm script
+### Step 1 — Update the changelog
+
+Before tagging, invoke the `/update-changelog` skill inline (do not ask the user to run it separately — run it as part of this flow):
+
+- Read the version from `package.json`
+- Collect commits since the last tag
+- Generate and commit the changelog entry to `master` on `origin`
+
+The changelog commit must exist on `master` **before** the tag is created, so it is included in the release.
+
+If changelog generation fails for any reason, stop and report the error. Do not proceed to tagging.
+
+---
+
+### Step 2 — Run the publish-npm script
 
 Run:
 ```bash
@@ -47,21 +61,21 @@ If it succeeds, note the tag name printed by the script (e.g. `v0.1.1`).
 
 ---
 
-### Step 2 — Locate the triggered workflow run
+### Step 3 — Locate the triggered workflow run
 
 Wait about 5 seconds for GitHub to register the tag push, then run:
 ```bash
 gh run list --repo aarthi-ntrjn/argus --workflow=publish-npm.yml --limit=5 --json databaseId,status,conclusion,headBranch,createdAt
 ```
 
-Find the run whose `headBranch` matches the tag pushed in Step 1. Note its `databaseId`.
+Find the run whose `headBranch` matches the tag pushed in Step 2. Note its `databaseId`.
 
 If no matching run appears after two attempts (10 seconds apart), report:
 "The workflow did not appear on the public repo. Check https://github.com/aarthi-ntrjn/argus/actions manually."
 
 ---
 
-### Step 3 — Poll until complete
+### Step 4 — Poll until complete
 
 Poll the run every 15 seconds using:
 ```bash
@@ -73,7 +87,7 @@ gh run view <databaseId> --repo aarthi-ntrjn/argus --json status,conclusion,jobs
 
 ---
 
-### Step 4 — Report the result
+### Step 5 — Report the result
 
 **On success** (`conclusion` is `success`):
 

--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -1,0 +1,133 @@
+---
+description: Auto-generate a CHANGELOG.md entry for the current version from commits since the last tag, and commit it to master.
+---
+
+## Invocation rules
+
+This skill may be invoked:
+- Explicitly by the user typing `/update-changelog`
+- Automatically as a step inside `/publish-npm` — in that case, skip the standalone invocation check and proceed directly
+
+If invoked as `/update-changelog` standalone, only run on `master`. If not on `master`, stop and say:
+"This skill must be run from `master`. You are currently on `<branch>`."
+
+---
+
+## Outline
+
+You are generating a human-readable changelog entry for the version about to be released.
+
+---
+
+### Step 1 — Read the new version
+
+Run:
+```bash
+node -e "console.log(require('./package.json').version)"
+```
+
+This is the version being released (e.g. `0.1.10`). The tag will be `v<version>`.
+
+---
+
+### Step 2 — Find the previous tag
+
+Run:
+```bash
+git describe --tags --abbrev=0
+```
+
+This is the last released tag (e.g. `v0.1.9`).
+
+---
+
+### Step 3 — Collect commits since last tag
+
+Run:
+```bash
+git --no-pager log <previous-tag>..HEAD --pretty=format:"%h %s" --no-merges
+```
+
+Collect the full list. These are the raw material for the entry.
+
+---
+
+### Step 4 — Categorize and write the changelog entry
+
+Using the commit list, write a `## [<version>] - <today's date YYYY-MM-DD>` section.
+
+**Categorization rules:**
+
+| Commit prefix | Changelog section |
+|---|---|
+| `feat` | ### Added |
+| `fix` | ### Fixed |
+| `perf`, `refactor` | ### Changed |
+| `docs` (user-facing only) | ### Changed |
+| `ci`, `chore`, `test`, `style`, `build` | Omit |
+| merge-gate fixes | Omit |
+| version bump commits | Omit |
+
+**Writing rules:**
+- Each bullet must be a clear, human-readable sentence — not a raw commit subject line.
+- Group related commits into a single bullet when they form one logical change.
+- Lead each bullet with a **bold noun phrase** (e.g. `**Session output streaming**`) for scanability.
+- Never use em dashes. Use a comma, colon, or reword instead.
+- Omit sections that have no entries (do not write empty `### Added` headers).
+- Do not include internal housekeeping, spec/task tracking commits, CI pipeline tweaks, or test-only fixes unless they directly affect the user.
+
+---
+
+### Step 5 — Prepend to CHANGELOG.md
+
+Read the current `CHANGELOG.md`. Insert the new section immediately after the header block (after the last line of the preamble, before the first `## [` entry).
+
+The result should look like:
+
+```markdown
+# Changelog
+
+All notable changes...
+
+The format is based on...
+
+## [0.1.10] - 2026-04-21
+
+### Added
+
+- **Feature name**: description of what it does.
+
+### Fixed
+
+- **Component**: description of what was fixed.
+
+## [0.1.9] - 2026-04-20
+...
+```
+
+Write the updated file.
+
+---
+
+### Step 6 — Commit
+
+Run:
+```bash
+git add CHANGELOG.md
+git commit -m "docs: update CHANGELOG for v<version>
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+Do NOT push. The push happens in the calling skill (`/publish-npm`).
+
+---
+
+### Step 7 — Report
+
+Print:
+```
+CHANGELOG updated for v<version> — <N> entries written.
+```
+
+List the bullet points that were added so the user can review them before the tag is created.

--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -1,6 +1,6 @@
 # argus2 Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2026-04-19
+Auto-generated from all feature plans. Last updated: 2026-04-20
 
 ## Active Technologies
 - TypeScript 5.9, Node.js 22 + node-pty (new), Fastify 5, better-sqlite3, ws, @fastify/websocket (020-fix-send-prompts)
@@ -23,6 +23,8 @@ Auto-generated from all feature plans. Last updated: 2026-04-19
 - HTML5, CSS3, JavaScript ES2020 (vanilla, no framework) + None (zero npm dependencies); shields.io CDN for dynamic badges (043-marketing-landing-page)
 - N/A (static files only) (043-marketing-landing-page)
 - TypeScript 5.x + React 18, lucide-react (icons), Tailwind CSS (046-github-feedback)
+- TypeScript 5.x, React 18 + React Query (`@tanstack/react-query`) for session output data; existing `sendPrompt` API (051-prompt-history)
+- In-memory only — history is not persisted across page reloads (051-prompt-history)
 
 - TypeScript 5.9 (frontend + backend) + Fastify 5.x (backend), React 18 + TailwindCSS 3 + React Query (frontend), better-sqlite3 (storage), pino (logging), vitest + Playwright (testing) (014-engineer-todo-list)
 
@@ -43,9 +45,9 @@ npm test; npm run lint
 TypeScript 5.9 (frontend + backend): Follow standard conventions
 
 ## Recent Changes
+- 051-prompt-history: Added TypeScript 5.x, React 18 + React Query (`@tanstack/react-query`) for session output data; existing `sendPrompt` API
 - 046-github-feedback: Added TypeScript 5.x + React 18, lucide-react (icons), Tailwind CSS
 - 043-marketing-landing-page: Added HTML5, CSS3, JavaScript ES2020 (vanilla, no framework) + None (zero npm dependencies); shields.io CDN for dynamic badges
-- 043-marketing-landing-page: Added [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION] + [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,134 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.9] - 2026-04-20
+
+### Added
+
+- **Markdown preview**: session card output stream now renders markdown formatting
+- **Copilot ask_user UX**: pending choice prompts from the Copilot `ask_user` tool are now broadcast via WebSocket and displayed in the UI
+
+### Fixed
+
+- Removed dead `@homebridge/node-pty-prebuilt-multiarch` dependency that broke installation on Node 25
+- Skip submit panel when an `ask_user` question has only one option
+- Advance `PendingChoicePanel` index correctly when user types via the session prompt bar
+
+### Changed
+
+- CI pipeline now enforces `--engine-strict` on `npm ci`
+
+---
+
+## [0.1.8] - 2026-04-19
+
+### Added
+
+- **Feedback menu**: GitHub feedback dropdown in Settings panel with bug report and feature request links
+- **About section**: Settings panel now includes links to the website, GitHub repo, and npm package
+- **Why Argus section**: landing page section explaining the attention and context-switching problem
+- **Privacy callout pills**: landing page How It Works section highlights privacy and telemetry posture
+- **Colored tagged logger**: `createTaggedLogger` utility for component-level colored log prefixes
+- **PID-based session pre-linking**: sessions launched via Argus are now linked by PID immediately, replacing the slower repo path scan
+
+### Fixed
+
+- Sticky header with border-bottom in the dashboard, matching the landing page nav style
+- Sidebar height and To Tackle panel now fill available viewport height correctly
+- Send button in session prompt bar replaced with a paper-plane SVG icon, properly centered
+- Error banner padding tightened and user-facing error messages made more descriptive on repo remove failure
+- PTY registry now supports multiple pending launchers per repo path
+- Active directory paths seeded from DB on server startup instead of requiring a full scan
+- Landing page hero headline centered and full-width; telemetry and privacy pill text updated
+
+---
+
+## [0.1.7] - 2026-04-19
+
+### Added
+
+- **Unified output ID scheme**: byte-offset plus block-index for both Claude and Copilot parsers, ensuring stable IDs across server restarts
+- **JsonlWatcherBase**: shared watcher logic extracted into a base class, fixing tail-read behavior and clear-on-attach
+
+### Fixed
+
+- Spaces in repo paths are now escaped when resolving the Claude project directory name
+- Trailing slashes stripped from repo paths on insert and lookup
+- Warning logged when a session working directory does not match any registered repository
+
+---
+
+## [0.1.6] - 2026-04-18
+
+### Fixed
+
+- Publish scripts (`/publish`, `/publish-npm`) guarded against accidental invocation
+- Null return from `execSync` (when `stdio` is `inherit`) handled in both publish scripts
+
+---
+
+## [0.1.5] - 2026-04-18
+
+### Added
+
+- **Headless environment detection**: Argus detects SSH and Codespaces environments on startup and skips terminal launch automatically
+- **Headless launch UX**: LaunchDropdown redesigned with inline copy icon per row; clicking a row in headless mode copies the command to clipboard
+- **Headless hint**: hint shown at the bottom of the launch menu in headless environments
+- **Cross-platform scripts**: `.mjs` equivalents added for all PowerShell automation scripts
+- Ubuntu added to tested-on badges in the landing page
+
+### Fixed
+
+- PTY input: focus-in/out xterm sequences sent before prompt delivery on POSIX
+- PTY write used for prompt delivery on POSIX instead of Win32 input sequences
+- Copilot process identified by command line (not `comm`) on Linux and Mac
+
+---
+
+## [0.1.4] - 2026-04-18
+
+### Added
+
+- `--version` / `-v` flag for the `argus` CLI binary
+- Uninstall and Cleanup section added to README
+
+### Fixed
+
+- Manual command shown when no terminal is available (headless environments and Codespaces)
+- Linux terminal handling stabilized; server no longer crashes on launch in Linux environments
+
+---
+
+## [0.1.3] - 2026-04-18
+
+### Fixed
+
+- `npx argus-ai-hub` now calls the compiled `launch.js` directly instead of using `npm --workspace`, fixing launch failures in published packages
+
+---
+
+## [0.1.2] - 2026-04-18
+
+### Fixed
+
+- Added `argus-ai-hub` bin entry to `package.json` so `npx argus-ai-hub` resolves correctly
+- Restored npm token auth while keeping `--provenance` for attestation
+
+---
+
+## [0.1.1] - 2026-04-18
+
+### Added
+
+- npm publish pipeline via OIDC Trusted Publishing
+- GitHub Pages deploy workflow for the landing page
+
+### Fixed
+
+- Added missing `dotenv` dependency to the published package
+
+---
+
 ## [0.1.0] - 2026-04-12
 
 First public release.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,15 @@ Every session card has a prompt bar. For **live** (PTY-launched) sessions, type 
 
 Prompt injection works for both Claude Code and Copilot CLI when started via `Launch with Argus`.
 
+#### Prompt History Navigation
+
+Press **Up arrow** to cycle backward through prompts you have sent in the current session. Press **Down arrow** to move forward again. Pressing Down past the most recent entry restores whatever draft text you had typed.
+
+- Works from any cursor position in the input field.
+- Includes prompts typed directly in the Claude/Copilot terminal (they appear as "you" messages in session output).
+- History is per session and capped at the 50 most recent entries.
+- A small position indicator (e.g. `2 / 5`) appears to the left of the input while you are navigating. It disappears when you return to draft mode or send a message.
+
 ### Repository Management
 
 <img src="docs/images/argus-repos.png" alt="Repository Cards" height="300">

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ These settings are saved in your browser (`localStorage`) and restored on every 
 
 ### About
 
-The bottom of the Settings panel has an **About** section with quick links to the Argus website, GitHub repository, and npm package page.
+The bottom of the Settings panel has an **About** section with quick links to the Argus website, GitHub repository, and npm package page. The current Argus version is displayed next to the heading (e.g. `v0.1.9`), sourced from the running server.
 
 ### Rescan Remote URLs
 

--- a/backend/src/api/routes/health.ts
+++ b/backend/src/api/routes/health.ts
@@ -25,7 +25,7 @@ const healthRoutes: FastifyPluginAsync = async (app) => {
     let version = '1.0.0';
     try {
       const require = createRequire(import.meta.url);
-      const pkg = require(join(__dirname, '..', '..', '..', 'package.json'));
+      const pkg = require(join(__dirname, '..', '..', '..', '..', 'package.json'));
       version = (pkg as { version?: string }).version ?? '1.0.0';
     } catch { /* use default */ }
 

--- a/frontend/src/__tests__/DashboardPage.mobile.test.tsx
+++ b/frontend/src/__tests__/DashboardPage.mobile.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import DashboardPage from '../pages/DashboardPage';
@@ -95,5 +96,18 @@ describe('DashboardPage — mobile layout', () => {
     // Wait for loading to finish
     await waitFor(() => expect(screen.queryByText('animate-pulse')).not.toBeInTheDocument());
     expect(screen.queryByRole('navigation', { name: /mobile navigation/i })).not.toBeInTheDocument();
+  });
+
+  it('toggles dashboard width from the header control on desktop', async () => {
+    mockUseIsMobile.mockReturnValue(false);
+    renderDashboard();
+
+    const expandButton = await screen.findByRole('button', { name: /expand dashboard width/i });
+    expect(expandButton).toHaveAttribute('aria-pressed', 'false');
+
+    await userEvent.click(expandButton);
+
+    const collapseButton = screen.getByRole('button', { name: /collapse dashboard width/i });
+    expect(collapseButton).toHaveAttribute('aria-pressed', 'true');
   });
 });

--- a/frontend/src/__tests__/SessionPromptBar.test.tsx
+++ b/frontend/src/__tests__/SessionPromptBar.test.tsx
@@ -1,16 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import SessionPromptBar from '../components/SessionPromptBar/SessionPromptBar';
 import type { Session } from '../types';
 
 vi.mock('../services/api', () => ({
   sendPrompt: vi.fn(),
+  interruptSession: vi.fn(),
+  getSessionOutput: vi.fn(),
 }));
 
-import { sendPrompt } from '../services/api';
+import { sendPrompt, getSessionOutput } from '../services/api';
 
 const mockSendPrompt = vi.mocked(sendPrompt);
+const mockGetSessionOutput = vi.mocked(getSessionOutput);
+
+function renderBar(session: Session) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <SessionPromptBar session={session} />
+    </QueryClientProvider>
+  );
+}
 
 const SESSION: Session = {
   id: 'session-abc-123',
@@ -35,47 +48,48 @@ describe('SessionPromptBar — input and send', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSendPrompt.mockResolvedValue({} as any);
+    mockGetSessionOutput.mockResolvedValue({ items: [], nextBefore: null, total: 0 });
   });
 
   it('renders an empty text input with the correct placeholder', () => {
-    render(<SessionPromptBar session={SESSION} />);
+    renderBar(SESSION);
     const input = screen.getByPlaceholderText('Send a prompt…');
     expect(input).toBeInTheDocument();
     expect(input).toHaveValue('');
   });
 
   it('Enter button is disabled when the input is empty', () => {
-    render(<SessionPromptBar session={SESSION} />);
+    renderBar(SESSION);
     expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
   });
 
   it('Enter button becomes enabled once text is typed', async () => {
-    render(<SessionPromptBar session={SESSION} />);
+    renderBar(SESSION);
     await userEvent.type(screen.getByPlaceholderText('Send a prompt…'), 'hello');
     expect(screen.getByRole('button', { name: 'Send' })).toBeEnabled();
   });
 
   it('Enter button stays disabled when input contains only whitespace', async () => {
-    render(<SessionPromptBar session={SESSION} />);
+    renderBar(SESSION);
     await userEvent.type(screen.getByPlaceholderText('Send a prompt…'), '   ');
     expect(screen.getByRole('button', { name: 'Send' })).toBeDisabled();
   });
 
   it('calls sendPrompt with the session id and trimmed text on button click', async () => {
-    render(<SessionPromptBar session={SESSION} />);
+    renderBar(SESSION);
     await userEvent.type(screen.getByPlaceholderText('Send a prompt…'), '  do something  ');
     await userEvent.click(screen.getByRole('button', { name: 'Send' }));
     expect(mockSendPrompt).toHaveBeenCalledWith(SESSION.id, 'do something');
   });
 
   it('calls sendPrompt when Enter is pressed in the input', async () => {
-    render(<SessionPromptBar session={SESSION} />);
+    renderBar(SESSION);
     await userEvent.type(screen.getByPlaceholderText('Send a prompt…'), 'run tests{Enter}');
     expect(mockSendPrompt).toHaveBeenCalledWith(SESSION.id, 'run tests');
   });
 
   it('clears the input after a successful send', async () => {
-    render(<SessionPromptBar session={SESSION} />);
+    renderBar(SESSION);
     const input = screen.getByPlaceholderText('Send a prompt…');
     await userEvent.type(input, 'hello');
     await userEvent.click(screen.getByRole('button', { name: 'Send' }));
@@ -84,14 +98,14 @@ describe('SessionPromptBar — input and send', () => {
 
   it('shows an error message when sendPrompt rejects', async () => {
     mockSendPrompt.mockRejectedValue(new Error('Network error'));
-    render(<SessionPromptBar session={SESSION} />);
+    renderBar(SESSION);
     await userEvent.type(screen.getByPlaceholderText('Send a prompt…'), 'hello');
     await userEvent.click(screen.getByRole('button', { name: 'Send' }));
     await waitFor(() => expect(screen.getByText('Network error')).toBeInTheDocument());
   });
 
   it('does not render a dropdown actions menu', () => {
-    render(<SessionPromptBar session={SESSION} />);
+    renderBar(SESSION);
     expect(screen.queryByRole('button', { name: /session actions menu/i })).not.toBeInTheDocument();
   });
 });
@@ -100,10 +114,11 @@ describe('SessionPromptBar — focus restoration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSendPrompt.mockResolvedValue({} as any);
+    mockGetSessionOutput.mockResolvedValue({ items: [], nextBefore: null, total: 0 });
   });
 
   it('refocuses the input after a successful send', async () => {
-    render(<SessionPromptBar session={SESSION} />);
+    renderBar(SESSION);
     const input = screen.getByPlaceholderText('Send a prompt…');
     await userEvent.type(input, 'hello');
     await userEvent.click(screen.getByRole('button', { name: 'Send' }));
@@ -117,27 +132,154 @@ describe('SessionPromptBar — read-only mode', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSendPrompt.mockResolvedValue({} as any);
+    mockGetSessionOutput.mockResolvedValue({ items: [], nextBefore: null, total: 0 });
   });
 
   it('hides the input when session is not PTY-launched', () => {
-    render(<SessionPromptBar session={READ_ONLY_SESSION} />);
+    renderBar(READ_ONLY_SESSION);
     expect(screen.queryByPlaceholderText('Send a prompt…')).not.toBeInTheDocument();
   });
 
   it('hides the enter button when session is not PTY-launched', () => {
-    render(<SessionPromptBar session={READ_ONLY_SESSION} />);
+    renderBar(READ_ONLY_SESSION);
     expect(screen.queryByRole('button', { name: 'Send' })).not.toBeInTheDocument();
   });
 
   it('shows a read-only message with a tooltip explaining how to enable prompts', () => {
-    render(<SessionPromptBar session={READ_ONLY_SESSION} />);
+    renderBar(READ_ONLY_SESSION);
     expect(screen.getByTitle(/argus launch/i)).toBeInTheDocument();
     expect(screen.getByText(/read-only/i)).toBeInTheDocument();
   });
 
   it('does not call sendPrompt in read-only mode', async () => {
-    render(<SessionPromptBar session={READ_ONLY_SESSION} />);
+    renderBar(READ_ONLY_SESSION);
     expect(mockSendPrompt).not.toHaveBeenCalled();
   });
 });
 
+// ---------------------------------------------------------------------------
+// History navigation — arrow keys
+// ---------------------------------------------------------------------------
+
+describe('SessionPromptBar — history navigation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSendPrompt.mockResolvedValue({} as any);
+    mockGetSessionOutput.mockResolvedValue({ items: [], nextBefore: null, total: 0 });
+  });
+
+  it('ArrowUp when no history has been sent leaves the input unchanged', async () => {
+    renderBar(SESSION);
+    const input = screen.getByPlaceholderText('Send a prompt…');
+    await userEvent.type(input, 'draft text');
+    await userEvent.keyboard('{ArrowUp}');
+    expect(input).toHaveValue('draft text');
+  });
+
+  it('ArrowUp after one send shows that sent prompt in the input', async () => {
+    renderBar(SESSION);
+    const input = screen.getByPlaceholderText('Send a prompt…');
+    await userEvent.type(input, 'first prompt');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(input).toHaveValue(''));
+    await userEvent.keyboard('{ArrowUp}');
+    expect(input).toHaveValue('first prompt');
+  });
+
+  it('ArrowUp twice shows the second-most-recent prompt', async () => {
+    renderBar(SESSION);
+    const input = screen.getByPlaceholderText('Send a prompt…');
+    await userEvent.type(input, 'first');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(input).toHaveValue(''));
+    await userEvent.type(input, 'second');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(input).toHaveValue(''));
+    await userEvent.keyboard('{ArrowUp}');
+    expect(input).toHaveValue('second');
+    await userEvent.keyboard('{ArrowUp}');
+    expect(input).toHaveValue('first');
+  });
+
+  it('ArrowDown after navigating up moves toward the newest entry', async () => {
+    renderBar(SESSION);
+    const input = screen.getByPlaceholderText('Send a prompt…');
+    await userEvent.type(input, 'first');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(input).toHaveValue(''));
+    await userEvent.type(input, 'second');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(input).toHaveValue(''));
+    await userEvent.keyboard('{ArrowUp}');
+    await userEvent.keyboard('{ArrowUp}');
+    expect(input).toHaveValue('first');
+    await userEvent.keyboard('{ArrowDown}');
+    expect(input).toHaveValue('second');
+  });
+
+  it('ArrowDown past the newest entry restores the draft text', async () => {
+    renderBar(SESSION);
+    const input = screen.getByPlaceholderText('Send a prompt…');
+    await userEvent.type(input, 'sent prompt');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(input).toHaveValue(''));
+    await userEvent.type(input, 'my draft');
+    await userEvent.keyboard('{ArrowUp}');
+    expect(input).toHaveValue('sent prompt');
+    await userEvent.keyboard('{ArrowDown}');
+    expect(input).toHaveValue('my draft');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// History mode indicator
+// ---------------------------------------------------------------------------
+
+describe('SessionPromptBar — history mode indicator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSendPrompt.mockResolvedValue({} as any);
+    mockGetSessionOutput.mockResolvedValue({ items: [], nextBefore: null, total: 0 });
+  });
+
+  it('does not show an indicator initially', () => {
+    renderBar(SESSION);
+    expect(screen.queryByText(/\d+ \/ \d+/)).not.toBeInTheDocument();
+  });
+
+  it('shows indicator after pressing ArrowUp when history exists', async () => {
+    renderBar(SESSION);
+    const input = screen.getByPlaceholderText('Send a prompt…');
+    await userEvent.type(input, 'a prompt');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(input).toHaveValue(''));
+    await userEvent.keyboard('{ArrowUp}');
+    expect(screen.getByText('1 / 1')).toBeInTheDocument();
+  });
+
+  it('indicator disappears after navigating back to draft', async () => {
+    renderBar(SESSION);
+    const input = screen.getByPlaceholderText('Send a prompt…');
+    await userEvent.type(input, 'a prompt');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(input).toHaveValue(''));
+    await userEvent.keyboard('{ArrowUp}');
+    expect(screen.getByText('1 / 1')).toBeInTheDocument();
+    await userEvent.keyboard('{ArrowDown}');
+    expect(screen.queryByText(/\d+ \/ \d+/)).not.toBeInTheDocument();
+  });
+
+  it('indicator disappears after sending a message', async () => {
+    renderBar(SESSION);
+    const input = screen.getByPlaceholderText('Send a prompt…');
+    await userEvent.type(input, 'first');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(input).toHaveValue(''));
+    await userEvent.keyboard('{ArrowUp}');
+    expect(screen.getByText('1 / 1')).toBeInTheDocument();
+    await userEvent.type(input, 'second');
+    await userEvent.keyboard('{Enter}');
+    await waitFor(() => expect(input).toHaveValue(''));
+    expect(screen.queryByText(/\d+ \/ \d+/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/SettingsPanel.test.tsx
+++ b/frontend/src/__tests__/SettingsPanel.test.tsx
@@ -10,6 +10,8 @@ import * as api from '../services/api';
 vi.mock('../services/api', () => ({
   getArgusSettings: vi.fn().mockResolvedValue({ autoRegisterRepos: false, yoloMode: false, restingThresholdMinutes: 20 } as any),
   patchArgusSettings: vi.fn().mockResolvedValue({ autoRegisterRepos: false, yoloMode: false, restingThresholdMinutes: 20 } as any),
+  getHealth: vi.fn().mockResolvedValue({ status: 'ok', version: '1.2.3', uptime: 0 }),
+  rescanRemoteUrls: vi.fn().mockResolvedValue(undefined),
 }));
 
 function renderWithQuery(ui: React.ReactElement) {
@@ -258,6 +260,21 @@ describe('SettingsPanel', () => {
       renderWithQuery(<SettingsPanel settings={allOff} onToggle={vi.fn()} />);
       await waitFor(() => screen.getByRole('checkbox', { name: /yolo mode/i }));
       expect(screen.queryByText(/all permission checks disabled/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('About section — version display', () => {
+    it('shows the version from the health endpoint next to the About heading', async () => {
+      renderWithQuery(<SettingsPanel settings={allOff} onToggle={vi.fn()} />);
+      await waitFor(() => {
+        expect(screen.getByText('v1.2.3')).toBeInTheDocument();
+      });
+    });
+
+    it('does not show a version when the health query has not resolved', () => {
+      vi.mocked(api.getHealth).mockReturnValue(new Promise(() => {}));
+      renderWithQuery(<SettingsPanel settings={allOff} onToggle={vi.fn()} />);
+      expect(screen.queryByText(/^v\d/)).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/__tests__/TelemetryBanner.test.tsx
+++ b/frontend/src/__tests__/TelemetryBanner.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { TelemetryBanner } from '../components/TelemetryBanner';
+
+describe('TelemetryBanner', () => {
+  it('opens settings from the opt-out action', async () => {
+    const onDismiss = vi.fn();
+    const onOpenSettings = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <TelemetryBanner onDismiss={onDismiss} onOpenSettings={onOpenSettings} subtle />
+      </MemoryRouter>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /opt out\?/i }));
+
+    expect(onOpenSettings).toHaveBeenCalledOnce();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('dismisses the notice without changing telemetry state directly', async () => {
+    const onDismiss = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <TelemetryBanner onDismiss={onDismiss} onOpenSettings={vi.fn()} subtle />
+      </MemoryRouter>
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /dismiss telemetry notice/i }));
+
+    expect(onDismiss).toHaveBeenCalledWith();
+  });
+});

--- a/frontend/src/__tests__/TelemetryBanner.test.tsx
+++ b/frontend/src/__tests__/TelemetryBanner.test.tsx
@@ -15,7 +15,7 @@ describe('TelemetryBanner', () => {
       </MemoryRouter>
     );
 
-    await userEvent.click(screen.getByRole('button', { name: /opt out\?/i }));
+    await userEvent.click(screen.getByRole('button', { name: /opt out/i }));
 
     expect(onOpenSettings).toHaveBeenCalledOnce();
     expect(onDismiss).not.toHaveBeenCalled();

--- a/frontend/src/__tests__/usePromptHistory.test.ts
+++ b/frontend/src/__tests__/usePromptHistory.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { usePromptHistory } from '../hooks/usePromptHistory';
+import type { SessionOutput } from '../types';
+
+function makeOutput(overrides: Partial<SessionOutput> = {}): SessionOutput {
+  return {
+    id: 'o1',
+    sessionId: 'session-1',
+    timestamp: new Date().toISOString(),
+    type: 'message',
+    content: 'hello',
+    toolName: null,
+    toolCallId: null,
+    role: 'user',
+    sequenceNumber: 1,
+    isMeta: false,
+    ...overrides,
+  };
+}
+
+const NO_OUTPUT: SessionOutput[] = [];
+
+// ---------------------------------------------------------------------------
+// navigateUp
+// ---------------------------------------------------------------------------
+
+describe('usePromptHistory — navigateUp', () => {
+  it('returns currentInput unchanged when no entries exist', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    let returned: string = '';
+    act(() => { returned = result.current.navigateUp('my draft'); });
+    expect(returned).toBe('my draft');
+    expect(result.current.isNavigating).toBe(false);
+  });
+
+  it('sets isNavigating to true after first up press when entries exist', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => { result.current.addEntry('first'); });
+    act(() => { result.current.navigateUp(''); });
+    expect(result.current.isNavigating).toBe(true);
+  });
+
+  it('returns most recent entry on first up press', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => {
+      result.current.addEntry('first');
+      result.current.addEntry('second');
+    });
+    let returned: string = '';
+    act(() => { returned = result.current.navigateUp(''); });
+    expect(returned).toBe('second');
+  });
+
+  it('returns older entries on subsequent up presses', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => {
+      result.current.addEntry('first');
+      result.current.addEntry('second');
+      result.current.addEntry('third');
+    });
+    const results: string[] = [];
+    act(() => { results.push(result.current.navigateUp('')); });
+    act(() => { results.push(result.current.navigateUp('')); });
+    act(() => { results.push(result.current.navigateUp('')); });
+    expect(results).toEqual(['third', 'second', 'first']);
+  });
+
+  it('is a no-op when already at oldest entry', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => { result.current.addEntry('only'); });
+    let r1: string = '', r2: string = '';
+    act(() => { r1 = result.current.navigateUp(''); });
+    act(() => { r2 = result.current.navigateUp(''); });
+    expect(r1).toBe('only');
+    expect(r2).toBe('only');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// navigateDown
+// ---------------------------------------------------------------------------
+
+describe('usePromptHistory — navigateDown', () => {
+  it('returns empty string and stays non-navigating when called without navigating first', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    let returned: string = 'untouched';
+    act(() => { returned = result.current.navigateDown(); });
+    expect(returned).toBe('');
+    expect(result.current.isNavigating).toBe(false);
+  });
+
+  it('moves toward newest when called after navigating up twice', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => {
+      result.current.addEntry('first');
+      result.current.addEntry('second');
+    });
+    act(() => { result.current.navigateUp(''); });
+    act(() => { result.current.navigateUp(''); });
+    let returned: string = '';
+    act(() => { returned = result.current.navigateDown(); });
+    expect(returned).toBe('second');
+  });
+
+  it('returns the saved draft and resets isNavigating when called past newest', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => { result.current.addEntry('one'); });
+    act(() => { result.current.navigateUp('my draft text'); });
+    let returned: string = '';
+    act(() => { returned = result.current.navigateDown(); });
+    expect(returned).toBe('my draft text');
+    expect(result.current.isNavigating).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Draft preservation
+// ---------------------------------------------------------------------------
+
+describe('usePromptHistory — draft preservation', () => {
+  it('saves the currentInput passed to the first navigateUp call', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => { result.current.addEntry('sent'); });
+    act(() => { result.current.navigateUp('half-typed text'); });
+    let returned: string = '';
+    act(() => { returned = result.current.navigateDown(); });
+    expect(returned).toBe('half-typed text');
+  });
+
+  it('restores empty string draft when input was empty before navigation', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => { result.current.addEntry('sent'); });
+    act(() => { result.current.navigateUp(''); });
+    let returned: string = '';
+    act(() => { returned = result.current.navigateDown(); });
+    expect(returned).toBe('');
+  });
+
+  it('does not change the draft if navigateUp is called again while already navigating', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => {
+      result.current.addEntry('first');
+      result.current.addEntry('second');
+    });
+    act(() => { result.current.navigateUp('original draft'); });
+    act(() => { result.current.navigateUp('this should not replace draft'); });
+    let returned: string = '';
+    act(() => { returned = result.current.navigateDown(); });
+    act(() => { returned = result.current.navigateDown(); });
+    expect(returned).toBe('original draft');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addEntry
+// ---------------------------------------------------------------------------
+
+describe('usePromptHistory — addEntry', () => {
+  it('adds text to history so it appears on next navigateUp', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => { result.current.addEntry('hello'); });
+    let returned: string = '';
+    act(() => { returned = result.current.navigateUp(''); });
+    expect(returned).toBe('hello');
+  });
+
+  it('resets isNavigating to false after adding an entry', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => { result.current.addEntry('one'); });
+    act(() => { result.current.navigateUp(''); });
+    expect(result.current.isNavigating).toBe(true);
+    act(() => { result.current.addEntry('two'); });
+    expect(result.current.isNavigating).toBe(false);
+  });
+
+  it('caps entries at 50, dropping the oldest', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => {
+      for (let i = 1; i <= 51; i++) {
+        result.current.addEntry(`msg-${i}`);
+      }
+    });
+    // Navigate to oldest — should be msg-2 (msg-1 was dropped)
+    const results: string[] = [];
+    act(() => {
+      for (let i = 0; i < 50; i++) {
+        results.push(result.current.navigateUp(''));
+      }
+    });
+    expect(results[49]).toBe('msg-2');
+    expect(results.includes('msg-1')).toBe(false);
+  });
+
+  it('does not add empty or whitespace-only strings', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => { result.current.addEntry('  '); });
+    let returned: string = '';
+    act(() => { returned = result.current.navigateUp('my draft'); });
+    expect(returned).toBe('my draft');
+    expect(result.current.isNavigating).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// indicator
+// ---------------------------------------------------------------------------
+
+describe('usePromptHistory — indicator', () => {
+  it('is null when not navigating', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    expect(result.current.indicator).toBeNull();
+  });
+
+  it('shows "1 / N" when at the most recent entry', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => {
+      result.current.addEntry('a');
+      result.current.addEntry('b');
+      result.current.addEntry('c');
+    });
+    act(() => { result.current.navigateUp(''); });
+    expect(result.current.indicator).toBe('1 / 3');
+  });
+
+  it('shows "N / N" when at the oldest entry', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => {
+      result.current.addEntry('a');
+      result.current.addEntry('b');
+    });
+    act(() => { result.current.navigateUp(''); });
+    act(() => { result.current.navigateUp(''); });
+    expect(result.current.indicator).toBe('2 / 2');
+  });
+
+  it('returns to null after navigating back to draft', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => { result.current.addEntry('one'); });
+    act(() => { result.current.navigateUp(''); });
+    expect(result.current.indicator).not.toBeNull();
+    act(() => { result.current.navigateDown(); });
+    expect(result.current.indicator).toBeNull();
+  });
+
+  it('returns to null after addEntry (send)', () => {
+    const { result } = renderHook(() => usePromptHistory('s1', NO_OUTPUT));
+    act(() => { result.current.addEntry('one'); });
+    act(() => { result.current.navigateUp(''); });
+    act(() => { result.current.addEntry('two'); });
+    expect(result.current.indicator).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Terminal message backfill (sessionOutputItems on mount)
+// ---------------------------------------------------------------------------
+
+describe('usePromptHistory — backfill from sessionOutputItems', () => {
+  it('seeds history from user messages in sessionOutputItems', () => {
+    const items: SessionOutput[] = [
+      makeOutput({ id: 'o1', content: 'terminal msg 1', sequenceNumber: 1 }),
+      makeOutput({ id: 'o2', content: 'terminal msg 2', sequenceNumber: 2 }),
+    ];
+    const { result } = renderHook(() => usePromptHistory('s1', items));
+    let r1: string = '', r2: string = '';
+    act(() => { r1 = result.current.navigateUp(''); });
+    act(() => { r2 = result.current.navigateUp(''); });
+    expect(r1).toBe('terminal msg 2');
+    expect(r2).toBe('terminal msg 1');
+  });
+
+  it('excludes isMeta entries from backfill', () => {
+    const items: SessionOutput[] = [
+      makeOutput({ id: 'o1', content: 'real msg', sequenceNumber: 1, isMeta: false }),
+      makeOutput({ id: 'o2', content: 'meta msg', sequenceNumber: 2, isMeta: true }),
+    ];
+    const { result } = renderHook(() => usePromptHistory('s1', items));
+    let returned: string = '';
+    act(() => { returned = result.current.navigateUp(''); });
+    act(() => { returned = result.current.navigateUp(''); });
+    expect(returned).toBe('real msg');
+  });
+
+  it('excludes assistant messages from backfill', () => {
+    const items: SessionOutput[] = [
+      makeOutput({ id: 'o1', content: 'user says', sequenceNumber: 1, role: 'user' }),
+      makeOutput({ id: 'o2', content: 'assistant says', sequenceNumber: 2, role: 'assistant' }),
+    ];
+    const { result } = renderHook(() => usePromptHistory('s1', items));
+    let r1: string = '', r2: string = '';
+    act(() => { r1 = result.current.navigateUp(''); });
+    act(() => { r2 = result.current.navigateUp(''); });
+    expect(r1).toBe('user says');
+    expect(r2).toBe('user says'); // no older entry — no-op
+  });
+
+  it('excludes empty-content entries', () => {
+    const items: SessionOutput[] = [
+      makeOutput({ id: 'o1', content: 'real', sequenceNumber: 1 }),
+      makeOutput({ id: 'o2', content: '   ', sequenceNumber: 2 }),
+    ];
+    const { result } = renderHook(() => usePromptHistory('s1', items));
+    let r1: string = '', r2: string = '';
+    act(() => { r1 = result.current.navigateUp(''); });
+    act(() => { r2 = result.current.navigateUp(''); });
+    expect(r1).toBe('real');
+    expect(r2).toBe('real'); // no-op at oldest
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Live sync and pendingBarSends deduplication
+// ---------------------------------------------------------------------------
+
+describe('usePromptHistory — live terminal message sync', () => {
+  it('adds new terminal messages that arrive after mount', () => {
+    const { result, rerender } = renderHook(
+      ({ items }: { items: SessionOutput[] }) => usePromptHistory('s1', items),
+      { initialProps: { items: [] as SessionOutput[] } },
+    );
+
+    const newItems: SessionOutput[] = [
+      makeOutput({ id: 'o1', content: 'live msg', sequenceNumber: 1 }),
+    ];
+
+    rerender({ items: newItems });
+
+    let returned: string = '';
+    act(() => { returned = result.current.navigateUp(''); });
+    expect(returned).toBe('live msg');
+  });
+
+  it('does not double-add a bar-sent message when it appears in session output', () => {
+    const { result, rerender } = renderHook(
+      ({ items }: { items: SessionOutput[] }) => usePromptHistory('s1', items),
+      { initialProps: { items: [] as SessionOutput[] } },
+    );
+
+    // User sends via bar
+    act(() => { result.current.addEntry('from bar'); });
+
+    // Session output picks it up
+    const withBarMsg: SessionOutput[] = [
+      makeOutput({ id: 'o1', content: 'from bar', sequenceNumber: 1 }),
+    ];
+    rerender({ items: withBarMsg });
+
+    // Navigate history — should appear exactly once
+    const results: string[] = [];
+    act(() => { results.push(result.current.navigateUp('')); });
+    act(() => { results.push(result.current.navigateUp('')); });
+    // Second navigateUp should be a no-op (only one entry)
+    expect(results[0]).toBe('from bar');
+    expect(results[1]).toBe('from bar'); // no-op
+    expect(results.filter((r) => r === 'from bar').length).toBe(2); // both at same entry, not two entries
+  });
+
+  it('correctly handles same text sent twice via bar', () => {
+    const { result, rerender } = renderHook(
+      ({ items }: { items: SessionOutput[] }) => usePromptHistory('s1', items),
+      { initialProps: { items: [] as SessionOutput[] } },
+    );
+
+    act(() => {
+      result.current.addEntry('dup text');
+      result.current.addEntry('dup text');
+    });
+
+    // Both appear in session output
+    const withTwoDups: SessionOutput[] = [
+      makeOutput({ id: 'o1', content: 'dup text', sequenceNumber: 1 }),
+      makeOutput({ id: 'o2', content: 'dup text', sequenceNumber: 2 }),
+    ];
+    rerender({ items: withTwoDups });
+
+    // Should still be exactly 2 entries (both from bar sends, session output deduplicated)
+    const results: string[] = [];
+    act(() => { results.push(result.current.navigateUp('')); });
+    act(() => { results.push(result.current.navigateUp('')); });
+    act(() => { results.push(result.current.navigateUp('')); });
+    expect(results[0]).toBe('dup text');
+    expect(results[1]).toBe('dup text');
+    expect(results[2]).toBe('dup text'); // no-op (still at oldest)
+  });
+});

--- a/frontend/src/components/OutputPane/OutputPane.tsx
+++ b/frontend/src/components/OutputPane/OutputPane.tsx
@@ -79,7 +79,7 @@ export default function OutputPane({ session, onClose, className, 'data-tour-id'
           )}
         </div>
       </div>
-      <div ref={scrollContainerRef} onScroll={handleScroll} className="flex-1 overflow-y-auto rounded-b-lg">
+      <div ref={scrollContainerRef} onScroll={handleScroll} className="flex-1 overflow-y-auto rounded-b-lg scroll-hover">
         {isError ? (
           <p className="p-6 text-center text-sm text-red-600">Failed to load output. Is the server running?</p>
         ) : (

--- a/frontend/src/components/SessionPromptBar/SessionPromptBar.tsx
+++ b/frontend/src/components/SessionPromptBar/SessionPromptBar.tsx
@@ -98,22 +98,28 @@ export default function SessionPromptBar({ session, onPromptSent }: Props) {
         <p className="text-xs text-amber-600 italic mb-1">Connecting to session…</p>
       )}
       <div className="flex gap-1 items-center">
-        {history.indicator && (
-          <span aria-live="polite" className="text-xs text-gray-500 shrink-0 tabular-nums">
-            {history.indicator}
-          </span>
-        )}
-        <input
-          ref={inputRef}
-          type="text"
-          value={prompt}
-          onChange={e => setPrompt(e.target.value)}
-          onKeyDown={handleKeyDown}
-          aria-label="Send a prompt to this session"
-          placeholder={isConnecting ? 'Connecting…' : 'Send a prompt…'}
-          disabled={sending || isConnecting}
-          className="flex-1 text-xs px-2 py-1 border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-400 disabled:opacity-50"
-        />
+        <div className="relative flex-1">
+          <input
+            ref={inputRef}
+            type="text"
+            value={prompt}
+            onChange={e => setPrompt(e.target.value)}
+            onKeyDown={handleKeyDown}
+            aria-label="Send a prompt to this session"
+            placeholder={isConnecting ? 'Connecting…' : 'Send a prompt…'}
+            disabled={sending || isConnecting}
+            className="w-full text-xs px-2 py-1 border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-blue-400 disabled:opacity-50"
+            style={history.indicator ? { paddingRight: '3rem' } : undefined}
+          />
+          {history.indicator && (
+            <span
+              aria-live="polite"
+              className="pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-xs text-gray-400 tabular-nums"
+            >
+              {history.indicator}
+            </span>
+          )}
+        </div>
         <Button
           size="sm"
           aria-label={sending ? 'Sending…' : 'Send'}

--- a/frontend/src/components/SessionPromptBar/SessionPromptBar.tsx
+++ b/frontend/src/components/SessionPromptBar/SessionPromptBar.tsx
@@ -1,8 +1,10 @@
 import { useState, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { CornerDownLeft } from 'lucide-react';
-import { sendPrompt, interruptSession } from '../../services/api';
+import { sendPrompt, interruptSession, getSessionOutput } from '../../services/api';
 import type { Session } from '../../types';
 import { Button } from '../Button';
+import { usePromptHistory } from '../../hooks/usePromptHistory';
 
 interface Props {
   session: Session;
@@ -20,6 +22,14 @@ export default function SessionPromptBar({ session, onPromptSent }: Props) {
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const { data: outputData } = useQuery({
+    queryKey: ['session-output', session.id],
+    queryFn: () => getSessionOutput(session.id, { limit: 100 }),
+    enabled: connectionState !== 'readonly',
+  });
+
+  const history = usePromptHistory(session.id, outputData?.items ?? []);
+
   const handleSend = async () => {
     const text = prompt.trim();
     if (!text) return;
@@ -27,6 +37,7 @@ export default function SessionPromptBar({ session, onPromptSent }: Props) {
     setSending(true);
     try {
       await sendPrompt(session.id, text);
+      history.addEntry(text);
       setPrompt('');
       onPromptSent?.();
     } catch (err) {
@@ -57,6 +68,18 @@ export default function SessionPromptBar({ session, onPromptSent }: Props) {
       e.stopPropagation();
       handleInterrupt();
     }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      const next = history.navigateUp(prompt);
+      setPrompt(next);
+    }
+    if (e.key === 'ArrowDown') {
+      if (history.isNavigating) {
+        e.preventDefault();
+        const next = history.navigateDown();
+        setPrompt(next);
+      }
+    }
   };
 
   if (connectionState === 'readonly') {
@@ -75,6 +98,11 @@ export default function SessionPromptBar({ session, onPromptSent }: Props) {
         <p className="text-xs text-amber-600 italic mb-1">Connecting to session…</p>
       )}
       <div className="flex gap-1 items-center">
+        {history.indicator && (
+          <span aria-live="polite" className="text-xs text-gray-500 shrink-0 tabular-nums">
+            {history.indicator}
+          </span>
+        )}
         <input
           ref={inputRef}
           type="text"

--- a/frontend/src/components/SettingsPanel/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel/SettingsPanel.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { RotateCcw, Bug, Lightbulb } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
 import type { DashboardSettings } from '../../types';
 import { useArgusSettings } from '../../hooks/useArgusSettings';
 import { YoloWarningDialog } from '../YoloWarningDialog/YoloWarningDialog';
 import { Checkbox } from '../Checkbox';
 import { Button } from '../Button';
-import { rescanRemoteUrls } from '../../services/api';
+import { rescanRemoteUrls, getHealth } from '../../services/api';
 import { buildBugReportUrl, buildFeatureRequestUrl } from '../../config/feedback';
 
 const DEFAULT_THRESHOLD = 20;
@@ -23,6 +24,7 @@ export function SettingsPanel({ settings, onToggle, onRestartTour }: SettingsPan
   const { settings: argusSettings, patchSetting } = useArgusSettings();
   const [showYoloWarning, setShowYoloWarning] = useState(false);
   const [rescanState, setRescanState] = useState<'idle' | 'scanning' | 'done'>('idle');
+  const { data: healthData } = useQuery({ queryKey: ['health'], queryFn: getHealth, staleTime: Infinity });
   const [thresholdInput, setThresholdInput] = useState(String(argusSettings?.restingThresholdMinutes ?? DEFAULT_THRESHOLD));
   const [thresholdError, setThresholdError] = useState<string | null>(null);
 
@@ -206,7 +208,12 @@ export function SettingsPanel({ settings, onToggle, onRestartTour }: SettingsPan
         </div>
 
         <div className="mt-2 pt-2 border-t border-gray-100">
-          <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2">About</p>
+          <div className="flex items-baseline justify-between mb-2">
+            <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">About</p>
+            {healthData?.version && (
+              <span className="text-xs text-gray-400 tabular-nums">v{healthData.version}</span>
+            )}
+          </div>
           <div className="flex flex-col gap-1">
             <a href="https://aarthi-ntrjn.github.io/argus" target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 text-sm text-gray-600 hover:text-blue-600">
               <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>

--- a/frontend/src/components/TelemetryBanner/TelemetryBanner.tsx
+++ b/frontend/src/components/TelemetryBanner/TelemetryBanner.tsx
@@ -1,15 +1,24 @@
 import { Link } from 'react-router-dom';
-import { useState } from 'react';
-import { Checkbox } from '../Checkbox';
 import { Button } from '../Button';
 
 interface TelemetryBannerProps {
-  onDismiss: (enabled: boolean) => void;
+  onDismiss: () => void;
+  onOpenSettings: () => void;
   subtle?: boolean;
 }
 
-export function TelemetryBanner({ onDismiss, subtle = false }: TelemetryBannerProps) {
-  const [enabled, setEnabled] = useState(true);
+const INLINE_ACTION_CLASSES = '!inline !p-0 !text-sm !font-normal align-baseline underline whitespace-nowrap';
+
+export function TelemetryBanner({ onDismiss, onOpenSettings, subtle = false }: TelemetryBannerProps) {
+  const textActionClassName = subtle
+    ? 'text-gray-500 hover:text-gray-700'
+    : 'text-blue-900 hover:text-blue-700';
+  const buttonActionClassName = subtle
+    ? `${INLINE_ACTION_CLASSES} !text-gray-500 hover:!text-gray-700`
+    : `${INLINE_ACTION_CLASSES} !text-blue-900 hover:!text-blue-700`;
+  const dismissClassName = subtle
+    ? 'icon-btn shrink-0 p-0 leading-none text-gray-400 hover:text-gray-600'
+    : 'icon-btn shrink-0 p-0 leading-none text-blue-700/70 hover:text-blue-700';
 
   if (subtle) {
     return (
@@ -19,23 +28,14 @@ export function TelemetryBanner({ onDismiss, subtle = false }: TelemetryBannerPr
         className="flex flex-wrap items-center gap-3 px-4 py-2.5 bg-gray-50 border border-gray-200 rounded-lg text-sm text-gray-500"
       >
         <span className="flex-1">
-          Argus collects anonymous usage data to improve the product. No personal information is sent.{' '}
-          <Link to="/telemetry" className="underline hover:text-gray-700 whitespace-nowrap">What we collect</Link>
+          Argus collects anonymous usage data to improve the product. No coding or personal information is sent.{' '}
+          <span className="inline-flex items-baseline gap-1">
+            <Link to="/telemetry" className={`${textActionClassName} underline whitespace-nowrap`}>What we collect</Link>
+            <span aria-hidden="true">-</span>
+            <Button type="button" variant="ghost" size="sm" className={buttonActionClassName} onClick={() => onOpenSettings()}>Opt out</Button>
+          </span>
         </span>
-        <Checkbox
-          label="Send telemetry"
-          aria-label="Enable anonymous telemetry"
-          checked={enabled}
-          onChange={e => setEnabled(e.target.checked)}
-        />
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => onDismiss(enabled)}
-          aria-label="Dismiss telemetry notice"
-        >
-          Got it
-        </Button>
+        <button type="button" onClick={() => onDismiss()} aria-label="Dismiss telemetry notice" className={dismissClassName}>&times;</button>
       </div>
     );
   }
@@ -47,23 +47,14 @@ export function TelemetryBanner({ onDismiss, subtle = false }: TelemetryBannerPr
       className="flex items-center gap-3 px-4 py-2 bg-blue-50 border-b border-blue-100 text-sm text-blue-900"
     >
       <span className="flex-1">
-        Argus collects anonymous usage data to improve the product. No personal information is sent.{' '}
-        <Link to="/telemetry" className="underline hover:text-blue-700 whitespace-nowrap">What we collect</Link>
+        Argus collects anonymous usage data to improve the product. No coding or personal information is sent.{' '}
+        <span className="inline-flex items-baseline gap-1">
+          <Link to="/telemetry" className={`${textActionClassName} underline whitespace-nowrap`}>What we collect</Link>
+          <span aria-hidden="true">-</span>
+          <Button type="button" variant="ghost" size="sm" className={buttonActionClassName} onClick={() => onOpenSettings()}>Opt out</Button>
+        </span>
       </span>
-      <Checkbox
-        label="Send telemetry"
-        aria-label="Enable anonymous telemetry"
-        checked={enabled}
-        onChange={e => setEnabled(e.target.checked)}
-      />
-      <Button
-        variant="primary"
-        size="sm"
-        onClick={() => onDismiss(enabled)}
-        aria-label="Dismiss telemetry notice"
-      >
-        Got it
-      </Button>
+      <button type="button" onClick={() => onDismiss()} aria-label="Dismiss telemetry notice" className={dismissClassName}>&times;</button>
     </div>
   );
 }

--- a/frontend/src/components/TelemetryBanner/TelemetryBanner.tsx
+++ b/frontend/src/components/TelemetryBanner/TelemetryBanner.tsx
@@ -5,10 +5,40 @@ import { Button } from '../Button';
 
 interface TelemetryBannerProps {
   onDismiss: (enabled: boolean) => void;
+  subtle?: boolean;
 }
 
-export function TelemetryBanner({ onDismiss }: TelemetryBannerProps) {
+export function TelemetryBanner({ onDismiss, subtle = false }: TelemetryBannerProps) {
   const [enabled, setEnabled] = useState(true);
+
+  if (subtle) {
+    return (
+      <div
+        role="note"
+        aria-label="Telemetry notice"
+        className="flex flex-wrap items-center gap-3 px-4 py-2.5 bg-gray-50 border border-gray-200 rounded-lg text-sm text-gray-500"
+      >
+        <span className="flex-1">
+          Argus collects anonymous usage data to improve the product. No personal information is sent.{' '}
+          <Link to="/telemetry" className="underline hover:text-gray-700 whitespace-nowrap">What we collect</Link>
+        </span>
+        <Checkbox
+          label="Send telemetry"
+          aria-label="Enable anonymous telemetry"
+          checked={enabled}
+          onChange={e => setEnabled(e.target.checked)}
+        />
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onDismiss(enabled)}
+          aria-label="Dismiss telemetry notice"
+        >
+          Got it
+        </Button>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/frontend/src/components/TodoPanel/TodoPanel.tsx
+++ b/frontend/src/components/TodoPanel/TodoPanel.tsx
@@ -239,7 +239,7 @@ export default function TodoPanel() {
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto scroll-hover">
         {/* Add row always visible regardless of loading state */}
         <div
           className="flex items-center gap-2 px-4 py-2 border-b border-gray-50 cursor-text"

--- a/frontend/src/hooks/usePromptHistory.ts
+++ b/frontend/src/hooks/usePromptHistory.ts
@@ -1,0 +1,146 @@
+import { useState, useEffect, useRef } from 'react';
+import type { SessionOutput } from '../types';
+
+export interface UsePromptHistoryResult {
+  isNavigating: boolean;
+  indicator: string | null;
+  navigateUp: (currentInput: string) => string;
+  navigateDown: () => string;
+  addEntry: (text: string) => void;
+  resetNavigation: () => void;
+}
+
+const HISTORY_CAP = 50;
+
+function isUserMessage(item: SessionOutput): boolean {
+  return item.role === 'user' && item.type === 'message' && !item.isMeta && item.content.trim() !== '';
+}
+
+export function usePromptHistory(
+  _sessionId: string,
+  sessionOutputItems: SessionOutput[],
+): UsePromptHistoryResult {
+  const initialEntries = sessionOutputItems
+    .filter(isUserMessage)
+    .sort((a, b) => a.sequenceNumber - b.sequenceNumber)
+    .map((item) => item.content.trim())
+    .slice(-HISTORY_CAP);
+
+  const [entries, setEntries] = useState<string[]>(initialEntries);
+  const [historyIndex, setHistoryIndex] = useState<number | null>(null);
+
+  const lastSeenSequence = useRef<number>(
+    sessionOutputItems.reduce((max, item) => Math.max(max, item.sequenceNumber), 0),
+  );
+  const pendingBarSends = useRef<Map<string, number>>(new Map());
+
+  // Sync refs immediately — updated in state setters to work correctly across
+  // multiple calls within the same act() block in tests.
+  const entriesRef = useRef<string[]>(initialEntries);
+  const historyIndexRef = useRef<number | null>(null);
+  const draftRef = useRef<string>('');
+
+  useEffect(() => {
+    const newItems = sessionOutputItems
+      .filter(isUserMessage)
+      .filter((item) => item.sequenceNumber > lastSeenSequence.current)
+      .sort((a, b) => a.sequenceNumber - b.sequenceNumber);
+
+    if (newItems.length === 0) return;
+
+    lastSeenSequence.current = newItems.reduce(
+      (max, item) => Math.max(max, item.sequenceNumber),
+      lastSeenSequence.current,
+    );
+
+    setEntries((prev) => {
+      let updated = [...prev];
+      for (const item of newItems) {
+        const text = item.content.trim();
+        const pending = pendingBarSends.current;
+        const count = pending.get(text) ?? 0;
+        if (count > 0) {
+          if (count === 1) {
+            pending.delete(text);
+          } else {
+            pending.set(text, count - 1);
+          }
+        } else {
+          updated = [...updated, text];
+        }
+      }
+      const next = updated.slice(-HISTORY_CAP);
+      entriesRef.current = next;
+      return next;
+    });
+  }, [sessionOutputItems]);
+
+  const isNavigating = historyIndex !== null;
+
+  const indicator =
+    historyIndex === null ? null : `${historyIndex + 1} / ${entries.length}`;
+
+  function navigateUp(currentInput: string): string {
+    const current = entriesRef.current;
+    const currentIndex = historyIndexRef.current;
+
+    if (current.length === 0) return currentInput;
+
+    let nextIndex: number;
+    if (currentIndex === null) {
+      draftRef.current = currentInput;
+      nextIndex = 0;
+    } else {
+      nextIndex = Math.min(currentIndex + 1, current.length - 1);
+    }
+
+    historyIndexRef.current = nextIndex;
+    setHistoryIndex(nextIndex);
+    return current[current.length - 1 - nextIndex] ?? currentInput;
+  }
+
+  function navigateDown(): string {
+    const current = entriesRef.current;
+    const currentIndex = historyIndexRef.current;
+    const savedDraft = draftRef.current;
+
+    if (currentIndex === null) return savedDraft;
+
+    if (currentIndex === 0) {
+      historyIndexRef.current = null;
+      setHistoryIndex(null);
+      return savedDraft;
+    }
+
+    const nextIndex = currentIndex - 1;
+    historyIndexRef.current = nextIndex;
+    setHistoryIndex(nextIndex);
+    return current[current.length - 1 - nextIndex] ?? savedDraft;
+  }
+
+  function addEntry(text: string): void {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+
+    pendingBarSends.current.set(
+      trimmed,
+      (pendingBarSends.current.get(trimmed) ?? 0) + 1,
+    );
+
+    setEntries((prev) => {
+      const next = [...prev, trimmed].slice(-HISTORY_CAP);
+      entriesRef.current = next;
+      return next;
+    });
+    historyIndexRef.current = null;
+    setHistoryIndex(null);
+    draftRef.current = '';
+  }
+
+  function resetNavigation(): void {
+    historyIndexRef.current = null;
+    setHistoryIndex(null);
+  }
+
+  return { isNavigating, indicator, navigateUp, navigateDown, addEntry, resetNavigation };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -13,4 +13,29 @@
   .icon-btn {
     @apply p-1 rounded-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-blue-400;
   }
+
+  /* Hover-only scrollbar: invisible until the element is hovered. */
+  .scroll-hover {
+    scrollbar-width: thin;
+    scrollbar-color: transparent transparent;
+    transition: scrollbar-color 0.2s;
+  }
+  .scroll-hover:hover {
+    scrollbar-color: rgb(203 213 225) transparent;
+  }
+  /* Webkit (Chrome, Safari, Edge) */
+  .scroll-hover::-webkit-scrollbar {
+    width: 6px;
+  }
+  .scroll-hover::-webkit-scrollbar-track {
+    background: transparent;
+  }
+  .scroll-hover::-webkit-scrollbar-thumb {
+    background-color: transparent;
+    border-radius: 9999px;
+    transition: background-color 0.2s;
+  }
+  .scroll-hover:hover::-webkit-scrollbar-thumb {
+    background-color: rgb(203 213 225);
+  }
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -340,7 +340,7 @@ export default function DashboardPage() {
                 {repoList}
               </div>
               {(!settings.hideTodoPanel || selectedSessionId) && (
-                <div className={`${selectedSessionId ? (isDashboardExpanded ? 'flex-[3]' : 'flex-1') : 'flex-[7]'} flex flex-col gap-4 min-h-0`}>
+                <div className={`${selectedSessionId ? (isDashboardExpanded ? 'flex-[3]' : 'flex-1') : 'flex-[7]'} flex flex-col gap-4 min-h-0 min-w-0`}>
                   {selectedSessionId && (() => {
                     const selectedSession = sessions.find(s => s.id === selectedSessionId);
                     return selectedSession ? (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -163,8 +163,8 @@ export default function DashboardPage() {
         <div className="flex-1 min-h-0 overflow-hidden">
           <div className={`mx-auto ${dashboardWidthClassName} h-full px-4 py-4 md:px-8 md:py-6 flex flex-col`}>
             <div className="animate-pulse flex gap-6 flex-1 min-h-0">
-              <div className="flex-[13] bg-gray-200 rounded-lg" />
-              <div className="flex-[7] bg-gray-200 rounded-lg" />
+              <div className={`${selectedSessionId ? (isDashboardExpanded ? 'flex-[2]' : 'flex-1') : 'flex-[13]'} bg-gray-200 rounded-lg`} />
+              <div className={`${selectedSessionId ? (isDashboardExpanded ? 'flex-[3]' : 'flex-1') : 'flex-[7]'} bg-gray-200 rounded-lg`} />
             </div>
           </div>
         </div>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { useRef, useState, useEffect, useMemo } from 'react';
-import { Plus, Check } from 'lucide-react';
+import { Plus, Check, Maximize2, Minimize2 } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { getSessions, getRepositories } from '../services/api';
 import { useSettings } from '../hooks/useSettings';
@@ -28,12 +28,15 @@ const ENDED_STATUSES = new Set(['completed', 'ended']);
 const ACTIVE_STATUSES = new Set(['active', 'waiting', 'error']);
 
 type MobileTab = 'sessions' | 'tasks';
+const MANAGED_DASHBOARD_WIDTH_CLASS = 'w-full max-w-[1600px]';
+const EXPANDED_DASHBOARD_WIDTH_CLASS = 'w-full max-w-none';
 
 export default function DashboardPage() {
   const navigate = useNavigate();
   const isMobile = useIsMobile();
 
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [isDashboardExpanded, setIsDashboardExpanded] = useState(false);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
     () => localStorage.getItem('selectedSessionId')
   );
@@ -52,8 +55,8 @@ export default function DashboardPage() {
   const [tourRun, setTourRun] = useState(false);
   const [catchUpRun, setCatchUpRun] = useState(false);
 
-  const handleTelemetryDismiss = (enabled: boolean) => {
-    patchSetting({ telemetryEnabled: enabled, telemetryPromptSeen: true });
+  const handleTelemetryDismiss = () => {
+    patchSetting({ telemetryPromptSeen: true });
   };
 
   const {
@@ -97,6 +100,10 @@ export default function DashboardPage() {
     queryKey: ['sessions'],
     queryFn: () => getSessions(),
   });
+
+  const dashboardWidthClassName = isDashboardExpanded
+    ? EXPANDED_DASHBOARD_WIDTH_CLASS
+    : MANAGED_DASHBOARD_WIDTH_CLASS;
 
   const sessionsByRepo = useMemo(() => {
     const map = new Map<string, Session[]>();
@@ -182,19 +189,25 @@ export default function DashboardPage() {
   );
 
   const emptyState = (
-    <div className="text-center py-16">
+    <div className="flex h-full min-h-[60vh] flex-col text-center">
       {repos.length === 0 ? (
-        <div className="space-y-1">
-          <p className="text-base text-gray-400">No repositories added yet.</p>
-          <p className="text-sm text-gray-400">Click "Add Repository" to start monitoring sessions.</p>
+        <>
+          <div className="flex-1 flex flex-col justify-center space-y-1">
+            <p className="text-xl font-semibold text-gray-400">No repositories added yet.</p>
+            <p className="text-xl text-gray-400">Click "<span className="font-semibold">Add Repositories</span>" to start managing sessions.</p>
+          </div>
           {argusSettings?.telemetryPromptSeen === false && (
-            <div className="mt-6 max-w-lg mx-auto text-left">
-              <TelemetryBanner onDismiss={handleTelemetryDismiss} subtle />
+            <div className="pt-8 max-w-lg mx-auto w-full text-left">
+              <TelemetryBanner
+                onDismiss={handleTelemetryDismiss}
+                onOpenSettings={() => setSettingsOpen(true)}
+                subtle
+              />
             </div>
           )}
-        </div>
+        </>
       ) : (
-        <div className="space-y-1">
+        <div className="flex-1 flex flex-col justify-center space-y-1">
           <p className="text-base text-gray-400">No repositories to show.</p>
           <p className="text-sm text-gray-400">All repositories are hidden by your current settings.</p>
         </div>
@@ -206,12 +219,32 @@ export default function DashboardPage() {
     <div className="min-h-screen bg-slate-50">
       {/* Sticky header */}
       <header className="bg-slate-50 border-b border-gray-200">
-        <div className="mx-auto max-w-screen-xl px-4 md:px-8 py-3 flex justify-between items-center">
+        <div className={`mx-auto ${dashboardWidthClassName} px-4 md:px-8 py-3 flex justify-between items-center`}>
           <h1 data-tour-id="dashboard-header" className="flex items-center gap-2 text-xl font-semibold text-gray-900">
             <ArgusLogo size={28} />
             Argus
           </h1>
           <div className="flex items-center gap-2">
+            <div className="relative">
+              <Button
+                variant={repos.length === 0 ? 'primary' : 'outline'}
+                data-tour-id="dashboard-add-repo"
+                onClick={handleAddRepo}
+                disabled={adding}
+                className="inline-flex items-center gap-1"
+              >
+                <Plus size={11} aria-hidden="true" />
+                {adding ? 'Adding...' : 'Add Repositories'}
+              </Button>
+              <span
+                role="status"
+                aria-live="polite"
+                className={`absolute right-0 top-full mt-1 inline-flex items-center gap-1 text-xs text-green-600 whitespace-nowrap transition-opacity duration-500 ${addInfo ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+              >
+                <Check size={11} aria-hidden="true" />
+                {infoSnapshot}
+              </span>
+            </div>
             <div className="relative" ref={settingsRef}>
               <button
                 data-tour-id="dashboard-settings"
@@ -240,32 +273,22 @@ export default function DashboardPage() {
                 />
               )}
             </div>
-            <div className="relative">
-              <Button
-                variant="outline"
-                data-tour-id="dashboard-add-repo"
-                onClick={handleAddRepo}
-                disabled={adding}
-                className="inline-flex items-center gap-1"
-              >
-                <Plus size={11} aria-hidden="true" />
-                {adding ? 'Adding...' : 'Add Repository'}
-              </Button>
-              <span
-                role="status"
-                aria-live="polite"
-                className={`absolute right-0 top-full mt-1 inline-flex items-center gap-1 text-xs text-green-600 whitespace-nowrap transition-opacity duration-500 ${addInfo ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
-              >
-                <Check size={11} aria-hidden="true" />
-                {infoSnapshot}
-              </span>
-            </div>
+            <button
+              type="button"
+              onClick={() => setIsDashboardExpanded(v => !v)}
+              aria-label={isDashboardExpanded ? 'Collapse dashboard width' : 'Expand dashboard width'}
+              aria-pressed={isDashboardExpanded}
+              title={isDashboardExpanded ? 'Collapse dashboard width' : 'Expand dashboard width'}
+              className="icon-btn text-gray-500 hover:text-blue-600"
+            >
+              {isDashboardExpanded ? <Minimize2 size={16} aria-hidden="true" /> : <Maximize2 size={16} aria-hidden="true" />}
+            </button>
           </div>
         </div>
       </header>
 
       {/* Page content */}
-      <div className="mx-auto max-w-screen-xl px-4 py-4 pb-20 md:px-8 md:py-6 md:pb-8">
+      <div className={`mx-auto ${dashboardWidthClassName} px-4 py-4 pb-20 md:px-8 md:py-6 md:pb-8`}>
 
         {addError && (
           <div role="alert" className="mb-4 px-3 py-2 bg-red-50 border border-red-200 rounded text-red-700 text-sm flex items-center justify-between gap-3">
@@ -287,9 +310,9 @@ export default function DashboardPage() {
           /* Desktop layout: two-column */
           reposWithSessions.length === 0 ? (
             <div className="flex gap-6 items-start">
-              <div className="flex-1">{emptyState}</div>
+              <div className="flex-1" style={{ height: 'calc(100vh - 8rem)' }}>{emptyState}</div>
               {!settings.hideTodoPanel && (
-                <div className="w-[400px] shrink-0 sticky top-8 flex flex-col" style={{ height: 'calc(100vh - 6rem)' }}>
+                <div className="w-[400px] shrink-0 sticky top-8 flex flex-col" style={{ height: 'calc(100vh - 8rem)' }}>
                   <TodoPanel />
                 </div>
               )}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -151,11 +151,22 @@ export default function DashboardPage() {
 
   if (reposLoading || sessionsLoading) {
     return (
-      <div className="min-h-screen bg-slate-50 p-4 md:p-8">
-        <div className="animate-pulse space-y-4">
-          {[1, 2, 3].map((i) => (
-            <div key={i} className="h-24 bg-gray-200 rounded-lg" />
-          ))}
+      <div className="h-screen flex flex-col overflow-hidden bg-slate-50">
+        <header className="shrink-0 bg-slate-50 border-b border-gray-200">
+          <div className={`mx-auto ${dashboardWidthClassName} px-4 md:px-8 py-3 flex justify-between items-center`}>
+            <h1 className="flex items-center gap-2 text-xl font-semibold text-gray-900">
+              <ArgusLogo size={28} />
+              Argus
+            </h1>
+          </div>
+        </header>
+        <div className="flex-1 min-h-0 overflow-hidden">
+          <div className={`mx-auto ${dashboardWidthClassName} h-full px-4 py-4 md:px-8 md:py-6 flex flex-col`}>
+            <div className="animate-pulse flex gap-6 flex-1 min-h-0">
+              <div className="flex-[13] bg-gray-200 rounded-lg" />
+              <div className="flex-[7] bg-gray-200 rounded-lg" />
+            </div>
+          </div>
         </div>
       </div>
     );

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -267,12 +267,6 @@ export default function DashboardPage() {
       {/* Page content */}
       <div className="mx-auto max-w-screen-xl px-4 py-4 pb-20 md:px-8 md:py-6 md:pb-8">
 
-        {repos.length > 0 && argusSettings?.telemetryPromptSeen === false && (
-          <div className="mb-4">
-            <TelemetryBanner onDismiss={handleTelemetryDismiss} subtle />
-          </div>
-        )}
-
         {addError && (
           <div role="alert" className="mb-4 px-3 py-2 bg-red-50 border border-red-200 rounded text-red-700 text-sm flex items-center justify-between gap-3">
             <span className="leading-snug">{addError}</span>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -36,7 +36,9 @@ export default function DashboardPage() {
   const isMobile = useIsMobile();
 
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [isDashboardExpanded, setIsDashboardExpanded] = useState(false);
+  const [isDashboardExpanded, setIsDashboardExpanded] = useState(
+    () => localStorage.getItem('isDashboardExpanded') === 'true'
+  );
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
     () => localStorage.getItem('selectedSessionId')
   );
@@ -216,9 +218,8 @@ export default function DashboardPage() {
   );
 
   return (
-    <div className="min-h-screen bg-slate-50">
-      {/* Sticky header */}
-      <header className="bg-slate-50 border-b border-gray-200">
+    <div className="h-screen flex flex-col overflow-hidden bg-slate-50">
+      <header className="shrink-0 bg-slate-50 border-b border-gray-200">
         <div className={`mx-auto ${dashboardWidthClassName} px-4 md:px-8 py-3 flex justify-between items-center`}>
           <h1 data-tour-id="dashboard-header" className="flex items-center gap-2 text-xl font-semibold text-gray-900">
             <ArgusLogo size={28} />
@@ -275,7 +276,11 @@ export default function DashboardPage() {
             </div>
             <button
               type="button"
-              onClick={() => setIsDashboardExpanded(v => !v)}
+              onClick={() => setIsDashboardExpanded(v => {
+                const next = !v;
+                localStorage.setItem('isDashboardExpanded', String(next));
+                return next;
+              })}
               aria-label={isDashboardExpanded ? 'Collapse dashboard width' : 'Expand dashboard width'}
               aria-pressed={isDashboardExpanded}
               title={isDashboardExpanded ? 'Collapse dashboard width' : 'Expand dashboard width'}
@@ -288,7 +293,8 @@ export default function DashboardPage() {
       </header>
 
       {/* Page content */}
-      <div className={`mx-auto ${dashboardWidthClassName} px-4 py-4 pb-20 md:px-8 md:py-6 md:pb-8`}>
+      <div className="flex-1 min-h-0 overflow-hidden">
+        <div className={`mx-auto ${dashboardWidthClassName} h-full px-4 py-4 md:px-8 md:py-6 flex flex-col`}>
 
         {addError && (
           <div role="alert" className="mb-4 px-3 py-2 bg-red-50 border border-red-200 rounded text-red-700 text-sm flex items-center justify-between gap-3">
@@ -299,7 +305,7 @@ export default function DashboardPage() {
 
         {/* Mobile layout: single column with bottom tab navigation */}
         {isMobile ? (
-          <div>
+          <div className="flex-1 min-h-0 overflow-y-auto pb-20 scroll-hover">
             {activeMobileTab === 'sessions' ? (
               reposWithSessions.length === 0 ? emptyState : repoList
             ) : (
@@ -309,25 +315,25 @@ export default function DashboardPage() {
         ) : (
           /* Desktop layout: two-column */
           reposWithSessions.length === 0 ? (
-            <div className="flex gap-6 items-start">
-              <div className="flex-1" style={{ height: 'calc(100vh - 8rem)' }}>{emptyState}</div>
+            <div className="flex-1 min-h-0 flex gap-6">
+              <div className="flex-[13] overflow-y-auto">{emptyState}</div>
               {!settings.hideTodoPanel && (
-                <div className="w-[400px] shrink-0 sticky top-8 flex flex-col" style={{ height: 'calc(100vh - 8rem)' }}>
+                <div className="flex-[7] flex flex-col">
                   <TodoPanel />
                 </div>
               )}
             </div>
           ) : (
-            <div className="flex gap-6 items-start">
-              <div className="flex-1 min-w-0">
+            <div className="flex-1 min-h-0 flex gap-6">
+              <div className={`${selectedSessionId ? (isDashboardExpanded ? 'flex-[2]' : 'flex-1') : 'flex-[13]'} min-w-0 overflow-y-auto scroll-hover`}>
                 {repoList}
               </div>
               {(!settings.hideTodoPanel || selectedSessionId) && (
-                <div className={`${selectedSessionId ? 'w-[640px]' : 'w-[400px]'} shrink-0 sticky top-8 flex flex-col gap-4`} style={{ height: 'calc(100vh - 6rem)' }}>
+                <div className={`${selectedSessionId ? (isDashboardExpanded ? 'flex-[3]' : 'flex-1') : 'flex-[7]'} flex flex-col gap-4 min-h-0`}>
                   {selectedSessionId && (() => {
                     const selectedSession = sessions.find(s => s.id === selectedSessionId);
                     return selectedSession ? (
-                      <div className={settings.hideTodoPanel ? 'flex-1 min-h-0' : 'flex-[4] min-h-0'}>
+                      <div className={settings.hideTodoPanel ? 'flex-1 min-h-0' : 'flex-[3] min-h-0'}>
                         <OutputPane
                           session={selectedSession}
                           onClose={() => selectSession(null)}
@@ -345,6 +351,7 @@ export default function DashboardPage() {
             </div>
           )
         )}
+      </div>
       </div>
 
       {/* Mobile bottom tab bar */}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -182,17 +182,22 @@ export default function DashboardPage() {
   );
 
   const emptyState = (
-    <div className="text-center py-16 text-gray-500">
+    <div className="text-center py-16">
       {repos.length === 0 ? (
-        <>
-          <p className="text-xl">No repositories registered.</p>
-          <p className="mt-2">Click "Add Repository" to get started.</p>
-        </>
+        <div className="space-y-1">
+          <p className="text-base text-gray-400">No repositories added yet.</p>
+          <p className="text-sm text-gray-400">Click "Add Repository" to start monitoring sessions.</p>
+          {argusSettings?.telemetryPromptSeen === false && (
+            <div className="mt-6 max-w-lg mx-auto text-left">
+              <TelemetryBanner onDismiss={handleTelemetryDismiss} subtle />
+            </div>
+          )}
+        </div>
       ) : (
-        <>
-          <p className="text-xl">No repositories to show.</p>
-          <p className="mt-2">All repositories are hidden by your current settings.</p>
-        </>
+        <div className="space-y-1">
+          <p className="text-base text-gray-400">No repositories to show.</p>
+          <p className="text-sm text-gray-400">All repositories are hidden by your current settings.</p>
+        </div>
       )}
     </div>
   );
@@ -262,10 +267,11 @@ export default function DashboardPage() {
       {/* Page content */}
       <div className="mx-auto max-w-screen-xl px-4 py-4 pb-20 md:px-8 md:py-6 md:pb-8">
 
-        {argusSettings?.telemetryPromptSeen === false && (
-          <TelemetryBanner onDismiss={handleTelemetryDismiss} />
+        {repos.length > 0 && argusSettings?.telemetryPromptSeen === false && (
+          <div className="mb-4">
+            <TelemetryBanner onDismiss={handleTelemetryDismiss} subtle />
+          </div>
         )}
-
 
         {addError && (
           <div role="alert" className="mb-4 px-3 py-2 bg-red-50 border border-red-200 rounded text-red-700 text-sm flex items-center justify-between gap-3">

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -149,6 +149,12 @@ export async function patchArgusSettings(patch: Partial<ArgusConfig>): Promise<A
   return apiFetch<ArgusConfig>('/settings', { method: 'PATCH', body: JSON.stringify(patch) });
 }
 
+export async function getHealth(): Promise<{ status: string; version: string; uptime: number }> {
+  const res = await fetch('/api/health');
+  if (!res.ok) throw new Error('Health check failed');
+  return res.json() as Promise<{ status: string; version: string; uptime: number }>;
+}
+
 export function postTelemetryEvent(type: string): void {
   void fetch(`${BASE}/telemetry/event`, {
     method: 'POST',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argus-ai-hub",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Your command center for Claude Code and GitHub Copilot CLI sessions. Watch every session live, send commands, and stop runaway agents, all from a single browser tab.",
   "license": "MIT",
   "homepage": "https://github.com/aarthi-ntrjn/argus#readme",

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -59,17 +59,22 @@ const remoteTag = execSync(`git ls-remote origin "refs/tags/${tag}"`, { encoding
 if (remoteTag) fail(`Tag ${tag} already exists on origin. Bump the version in package.json first.`);
 ok(`Tag ${tag} is available`);
 
-// 5. Create annotated tag
+// 5. Push master to origin so the changelog commit is included before tagging
+step('Pushing master to origin (ensures changelog commit is included in tag)');
+run(`git push origin master`, { inherit: true });
+ok('master pushed to origin');
+
+// 6. Create annotated tag
 step(`Creating annotated tag ${tag}`);
 run(`git tag -a ${tag} -m "Release ${tag}"`);
 ok(`Created local tag ${tag}`);
 
-// 6. Push tag to origin (private)
+// 7. Push tag to origin (private)
 step(`Pushing tag ${tag} to origin (private)`);
 run(`git push origin ${tag}`, { inherit: true });
 ok('Pushed to origin');
 
-// 7. Push tag to public (triggers publish-npm workflow)
+// 8. Push tag to public (triggers publish-npm workflow)
 step(`Pushing tag ${tag} to ${PUBLIC_REMOTE} (public)`);
 run(`git push ${PUBLIC_REMOTE} ${tag}`, { inherit: true });
 ok(`Pushed to ${PUBLIC_REMOTE}`);

--- a/specs/050-homebridge-npm-install/spec.md
+++ b/specs/050-homebridge-npm-install/spec.md
@@ -1,0 +1,128 @@
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`  
+**Created**: [DATE]  
+**Status**: Draft  
+**Input**: User description: "$ARGUMENTS"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently - e.g., "Can be fully tested by [specific action] and delivers [specific value]"]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+2. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 2 - [Brief Title] (Priority: P2)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 3 - [Brief Title] (Priority: P3)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when [boundary condition]?
+- How does system handle [error scenario]?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
+- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
+- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
+- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
+- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents, key attributes without implementation]
+- **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable metric, e.g., "Users can complete account creation in under 2 minutes"]
+- **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
+- **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
+- **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]
+
+## Assumptions
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right assumptions based on reasonable defaults
+  chosen when the feature description did not specify certain details.
+-->
+
+- [Assumption about target users, e.g., "Users have stable internet connectivity"]
+- [Assumption about scope boundaries, e.g., "Mobile support is out of scope for v1"]
+- [Assumption about data/environment, e.g., "Existing authentication system will be reused"]
+- [Dependency on existing system/service, e.g., "Requires access to the existing user profile API"]

--- a/specs/051-prompt-history/checklists/requirements.md
+++ b/specs/051-prompt-history/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Session Prompt History Navigation
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- User explicitly specified that up arrow triggers from any cursor position (FR-012), not just when input is empty — this is the primary design distinction from common alternatives.
+- Terminal "you" messages inclusion (FR-007/FR-008/Story 3) is a key scope decision confirmed by the user.
+- Draft preservation (FR-006/Story 2) is fully specified — no ambiguity remains.
+- History cap of 50 entries is a documented assumption; can be revisited in planning.

--- a/specs/051-prompt-history/data-model.md
+++ b/specs/051-prompt-history/data-model.md
@@ -1,0 +1,104 @@
+# Data Model: Session Prompt History Navigation
+
+**Branch**: `051-prompt-history` | **Date**: 2026-04-20
+
+All data structures are in-memory only. No database schema changes.
+
+---
+
+## Types
+
+### `PromptHistoryState` (internal hook state)
+
+```typescript
+interface PromptHistoryState {
+  entries: string[];           // All history entries, chronological order (oldest[0], newest[N-1])
+  historyIndex: number | null; // null = draft mode; 0 = most recent entry, 1 = second most recent, ...
+  draft: string;               // Saved input text before first up arrow press this navigation session
+  pendingBarSends: Map<string, number>; // text → count of bar-sent messages not yet seen in session output
+  lastSeenSequence: number;    // Highest sequenceNumber processed from session output
+}
+```
+
+### `UsePromptHistoryResult` (hook public API)
+
+```typescript
+interface UsePromptHistoryResult {
+  isNavigating: boolean;       // true when historyIndex !== null
+  indicator: string | null;    // e.g., "3 / 12" while navigating, null otherwise
+  navigateUp: (currentInput: string) => string;  // returns text to display; saves draft on first call
+  navigateDown: () => string;  // returns text to display; returns draft when past newest entry
+  addEntry: (text: string) => void;  // called on send; resets navigation state
+  resetNavigation: () => void; // resets to draft mode without sending
+}
+```
+
+---
+
+## Invariants
+
+- `entries.length <= 50` — entries beyond the cap are dropped (oldest first).
+- `historyIndex` is always in range `[0, entries.length - 1]` when not null.
+- `draft` is only meaningful when `historyIndex !== null`; it holds the exact string present in the input at the moment `historyIndex` transitioned from `null` to `0`.
+- `pendingBarSends` counts are always non-negative. A key is deleted when its count reaches 0.
+- `lastSeenSequence` starts at 0 and only increases. It prevents processing the same session output entries twice across re-renders.
+
+---
+
+## State Transitions
+
+```
+Initial:
+  entries = [existing "you" messages from session output]
+  historyIndex = null
+  draft = ''
+  pendingBarSends = {}
+  lastSeenSequence = max(sequenceNumber of existing entries)
+
+ArrowUp pressed (historyIndex === null):
+  draft ← currentInput
+  historyIndex ← 0
+  input ← entries[entries.length - 1]  (most recent)
+
+ArrowUp pressed (historyIndex > 0):
+  historyIndex ← historyIndex + 1
+  input ← entries[entries.length - 1 - historyIndex]
+
+ArrowUp pressed (historyIndex === entries.length - 1):
+  no-op (at oldest entry)
+
+ArrowDown pressed (historyIndex > 0):
+  historyIndex ← historyIndex - 1
+  input ← entries[entries.length - 1 - historyIndex]
+
+ArrowDown pressed (historyIndex === 0):
+  historyIndex ← null
+  input ← draft
+
+Send (addEntry called):
+  entries ← [...entries, text].slice(-50)  (cap at 50, drop oldest)
+  pendingBarSends[text] ← (pendingBarSends[text] ?? 0) + 1
+  historyIndex ← null
+  draft ← ''
+
+New session output "you" message (sequence > lastSeenSequence):
+  if pendingBarSends[text] > 0:
+    pendingBarSends[text] -= 1
+    if pendingBarSends[text] === 0: delete pendingBarSends[text]
+    // already in entries from addEntry — skip
+  else:
+    entries ← [...entries, text].slice(-50)
+  lastSeenSequence ← max(lastSeenSequence, sequenceNumber)
+```
+
+---
+
+## Source of "You" Messages
+
+Session output items qualify as history entries when ALL of the following hold:
+- `role === 'user'`
+- `type === 'message'`
+- `isMeta !== true`
+- `content` is non-empty (after trim)
+
+These are extracted from the React Query cache for key `['session-output', sessionId]`.

--- a/specs/051-prompt-history/plan.md
+++ b/specs/051-prompt-history/plan.md
@@ -1,0 +1,121 @@
+# Implementation Plan: Session Prompt History Navigation
+
+**Branch**: `051-prompt-history` | **Date**: 2026-04-20 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/051-prompt-history/spec.md`
+
+## Summary
+
+Add up/down arrow key history navigation to the `SessionPromptBar` component. Users can cycle through previously sent prompts (from both the Argus prompt bar and the Claude/Copilot terminal "you" messages) without retyping. The currently typed draft is preserved and restored when navigating back past the newest entry. A subtle inline indicator shows the history position while navigating.
+
+This is a **pure frontend feature**: no backend changes, no new API endpoints, no database changes. All history state lives in-memory in a new `usePromptHistory` React hook.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x, React 18  
+**Primary Dependencies**: React Query (`@tanstack/react-query`) for session output data; existing `sendPrompt` API  
+**Storage**: In-memory only — history is not persisted across page reloads  
+**Testing**: Vitest + React Testing Library + `@testing-library/user-event` (existing test setup)  
+**Target Platform**: Browser (all OS) — keyboard events use standard `e.key` values  
+**Project Type**: Web application (frontend only)  
+**Performance Goals**: 100ms per keypress response (SC-004, SC-006) — trivially met by in-memory state transitions  
+**Constraints**: 50-entry cap per session; no deduplication; no persistence  
+**Scale/Scope**: Single-user localhost tool; per-session history up to 50 entries
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| §I Engineering (reliable, observable, testable, reversible) | PASS | Hook is pure and unit-testable; feature flag not needed (additive only) |
+| §II Architecture (versioned API boundaries) | EXCEPTION | Pure frontend; no new service boundary created |
+| §III Code Standards (readable, functions < 50 lines, docs) | PASS | Hook functions split into focused helpers; public hook API documented |
+| §IV Test-First | PASS | Tests written before implementation in tasks |
+| §V Testing (unit + integration + e2e coverage) | PASS | Unit tests for hook; component tests for bar; no regression |
+| §VI Security (auth/authz) | EXCEPTION | Localhost-only tool per §VI exception; no auth surface changes |
+| §VII Observability (structured logs, metrics) | EXCEPTION | Client-side UX feature; no backend metrics relevant |
+| §VIII Performance (100ms p95) | PASS | In-memory state, zero I/O on keypress |
+| §IX AI Usage | PASS | Human review required before merge |
+| §X Definition of Done | PASS | All criteria addressed in tasks |
+| §XI Documentation | PASS | README.md updated in same PR (task T-last) |
+| §XII Error Handling | PASS | No new async paths; existing error handling unchanged |
+
+> **§XI Documentation**: README.md MUST be updated in the same PR as this user-facing change.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/051-prompt-history/
+├── plan.md              # This file
+├── research.md          # Phase 0 decisions
+├── data-model.md        # In-memory data shapes
+└── tasks.md             # Dependency-ordered task list
+```
+
+### Source Code (files created or modified)
+
+```text
+frontend/
+├── src/
+│   ├── hooks/
+│   │   └── usePromptHistory.ts          # NEW — history state hook
+│   └── components/
+│       └── SessionPromptBar/
+│           └── SessionPromptBar.tsx     # MODIFIED — arrow key handling + indicator
+└── src/
+    └── __tests__/
+        ├── usePromptHistory.test.ts     # NEW — hook unit tests
+        └── SessionPromptBar.test.tsx    # MODIFIED — new history navigation tests
+```
+
+**Structure Decision**: Frontend-only, single workspace (`frontend/`). No backend files touched.
+
+## Implementation Approach
+
+### History State Hook: `usePromptHistory`
+
+The hook encapsulates all history logic and is the sole owner of history state.
+
+**Inputs:**
+- `sessionId: string` — used as the react-query cache key for session output
+- `sessionOutputItems: SessionOutput[]` — passed in from the parent (avoids double-fetching; `OutputPane` already fetches this)
+
+**State:**
+- `entries: string[]` — all history entries in chronological order, newest last; capped at 50
+- `historyIndex: number | null` — `null` = draft mode; `0` = most recent (index from end); increments going further back
+- `draft: string` — text saved when user first presses up arrow
+
+**Returned API:**
+- `isNavigating: boolean` — `historyIndex !== null`
+- `indicator: string | null` — e.g., `"3 / 12"` while navigating, `null` otherwise
+- `navigateUp(currentInput: string): string` — returns the text to show; saves draft on first call
+- `navigateDown(): string` — returns next newer text, or draft when past the end
+- `addEntry(text: string): void` — appends to entries (called on send), resets navigation state
+- `resetNavigation(): void` — returns to draft mode (called on send or explicit reset)
+
+### Terminal Message Backfill and Sync
+
+`SessionPromptBar` will use `useQuery(['session-output', session.id])` — the same query key used by `OutputPane`. React Query serves the cached result, so there is no double network request.
+
+The hook derives terminal "you" messages from `sessionOutputItems` (entries where `role === 'user'` and `type === 'message'` and `!isMeta`).
+
+**Bar-sent message deduplication**: When the user sends via the bar, the message is typed into the PTY and will eventually appear in session output as a "you" message. To prevent double-counting:
+- Keep a `pendingBarSends: Map<string, number>` (text → count of pending sends).
+- On `addEntry(text)`: increment count in `pendingBarSends`.
+- When session output gains new "you" messages: for each one, if it exists in `pendingBarSends` (count > 0), decrement and skip (already in `entries`); otherwise add to `entries`.
+
+This correctly handles the user sending the same text multiple times.
+
+### History Mode Indicator
+
+While `historyIndex !== null`, display `"{position} / {total}"` next to the input where position = index from newest (1 = most recent). Rendered as a small `<span>` inside the prompt bar row. Disappears on send or when navigating back to draft.
+
+### Up Arrow Key Behavior
+
+`e.key === 'ArrowUp'` in `handleKeyDown`: call `navigateUp(prompt)`, set the returned text as `prompt`. Use `e.preventDefault()` to suppress browser default (cursor movement to start of input). This override applies regardless of cursor position in the input (FR-012).
+
+### Down Arrow Key Behavior
+
+`e.key === 'ArrowDown'` in `handleKeyDown`: call `navigateDown()`, set returned text. Only prevent default when actively navigating (`isNavigating`); otherwise allow browser default.

--- a/specs/051-prompt-history/research.md
+++ b/specs/051-prompt-history/research.md
@@ -1,0 +1,65 @@
+# Research: Session Prompt History Navigation
+
+**Branch**: `051-prompt-history` | **Date**: 2026-04-20
+
+## Decision Log
+
+### D-001: History state location — component-local vs shared hook
+
+**Decision**: Extract into a dedicated `usePromptHistory` hook (not inline state in the component).
+
+**Rationale**: The history logic involves multiple interacting state variables (`entries`, `historyIndex`, `draft`, `pendingBarSends`) and a useEffect to sync with session output. Keeping this inline in `SessionPromptBar` would push the component past 50 lines (§III) and make the logic hard to test in isolation (§I). A hook allows unit tests without rendering the full component.
+
+**Alternatives considered**:
+- Inline state in `SessionPromptBar`: simpler, but violates function-size and testability principles.
+- Context/global store: overkill; history is per-session and belongs to the session view scope.
+
+---
+
+### D-002: Source of terminal "you" messages — new query vs shared cache
+
+**Decision**: Call `useQuery(['session-output', session.id])` inside `SessionPromptBar`. React Query's shared cache means `OutputPane` (which uses the same key) has already populated the cache; no second network request is made.
+
+**Rationale**: The alternative — passing `sessionOutputItems` as a prop from `SessionPage` — would require `SessionPage` to fetch output itself (double fetch) or thread a prop through `OutputPane`, which leaks internal concerns upward. Cache sharing is the idiomatic React Query pattern.
+
+**Alternatives considered**:
+- Prop drilling from `SessionPage`: requires `SessionPage` to own session output fetch, conflicting with the current design where `OutputPane` owns it.
+- Callback/ref from `OutputPane`: overly complex and creates tight coupling between sibling components.
+
+---
+
+### D-003: Bar-sent message deduplication strategy
+
+**Decision**: Use a `Map<string, number>` (text → pending count) to track bar-sent messages that have not yet appeared in session output. When new session output "you" messages arrive, decrement the count for matching text before adding to history entries.
+
+**Rationale**: Bar-sent messages are typed into the PTY and appear in session output (as Claude/Copilot JSONL "user" entries) after a short delay. Without deduplication, the same message would appear twice: once on send (immediately) and once when session output updates. The Map approach handles repeated identical sends correctly.
+
+**Alternatives considered**:
+- No deduplication (accept brief duplicates): poor UX — user sees their message appear twice for a few seconds.
+- Session output only (no immediate add): violates FR-007; bar message missing from history until the next query refetch (~5s).
+- `Set<string>` instead of `Map<string, number>`: fails when the same text is sent twice in quick succession (count becomes negative).
+
+---
+
+### D-004: Up arrow default browser behavior suppression
+
+**Decision**: Always call `e.preventDefault()` on `ArrowUp` when the input is focused (regardless of cursor position), to suppress the browser's native "move cursor to start" behavior.
+
+**Rationale**: FR-012 requires up arrow to work from any cursor position. The browser default for `ArrowUp` in a text input is to move the cursor to the start of the line. This conflicts directly with history navigation. Suppressing it is the correct and expected behavior (matching shells, browser address bars, etc.).
+
+**Alternatives considered**:
+- Only suppress when `historyIndex === null` (first press): would leave cursor-jump behavior on subsequent presses when `historyIndex > 0`, creating inconsistency.
+- Suppress only when cursor is at position 0: violates FR-012 (must work from any position).
+
+---
+
+### D-005: History mode indicator placement
+
+**Decision**: Render the indicator as a small `<span>` inside the existing prompt bar row, to the left of the input field (or as a subtle overlay). Use a fixed-width format `"{n} / {total}"`.
+
+**Rationale**: The indicator must appear within 100ms (SC-006) and disappear automatically. Inline in the same flex row avoids layout shift in other parts of the UI. The format "3 / 12" is familiar from browser and editor history navigation patterns.
+
+**Alternatives considered**:
+- Tooltip: less visible; requires hover on mobile.
+- Toast notification: inappropriate for a real-time per-keypress indicator.
+- Badge next to the send button: possible but more complex; left-of-input is more conventional.

--- a/specs/051-prompt-history/spec.md
+++ b/specs/051-prompt-history/spec.md
@@ -1,0 +1,229 @@
+# Feature Specification: Session Prompt History Navigation
+
+**Feature Branch**: `051-prompt-history`
+**Created**: 2026-04-20
+**Status**: Draft
+**Input**: User description: "when i hit the up arrow i want to see the previous requests in this session. The up arrow key can be anywhere in the input. The currently typed text should also be in list of queries. this should be per session. and some user queries can be sent from claude or copilot terminal. they show as you messages and they should also be in the list."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Navigate History with Up/Down Arrow Keys (Priority: P1)
+
+As a user working in a session, I want to press the up arrow key in the prompt input to cycle backward through all previous requests sent in this session, so I can quickly resend or edit past prompts without retyping them.
+
+**Why this priority**: History navigation is the core feature. It eliminates the most common friction point: retyping the same or similar prompts repeatedly during a session.
+
+**Independent Test**: Send two prompts via the Argus prompt bar. Focus the prompt input (with any content, including empty). Press up arrow once — the most recent sent prompt appears. Press up again — the second-to-last prompt appears. Press down — the most recent prompt reappears. Fully testable on its own.
+
+**Acceptance Scenarios**:
+
+1. **Given** at least one prompt has been sent in the session and the prompt input is focused, **When** the user presses the up arrow key, **Then** the input is replaced with the most recently sent prompt in this session.
+2. **Given** the user is viewing a history entry, **When** the user presses up arrow again, **Then** the next older prompt appears in the input.
+3. **Given** the user has navigated to the oldest history entry, **When** the user presses up arrow again, **Then** nothing changes (oldest entry stays; no wrap-around).
+4. **Given** the user is viewing a history entry, **When** the user presses the down arrow, **Then** the next more-recent prompt appears.
+5. **Given** the user has navigated forward past the most recent history entry, **When** down arrow is pressed one more time, **Then** the input restores to the draft text that was present before history navigation began.
+6. **Given** no prompts have been sent yet in this session, **When** the user presses up arrow, **Then** nothing happens (no error, no change).
+
+---
+
+### User Story 2 - Current Draft Preserved as Navigable Entry (Priority: P1)
+
+As a user who has partially typed a prompt, I want my in-progress text to be preserved and reachable when I navigate the history, so that pressing up and then down again restores exactly what I had typed.
+
+**Why this priority**: Without draft preservation, navigating history silently destroys whatever the user was typing — a frustrating and common source of lost work.
+
+**Independent Test**: Type "my new message" in the prompt bar (do not send it). Press up arrow — a past message appears. Press down arrow until past the last history entry — "my new message" is restored exactly as typed. Testable independently.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user has typed text in the prompt input, **When** the user presses up arrow to start navigating history, **Then** the current input text is saved as a draft.
+2. **Given** the user has navigated into history and presses down past the most recent sent message, **Then** the prompt input shows the saved draft text exactly as it was before navigation began.
+3. **Given** the draft is empty (user typed nothing before navigating), **When** the user returns to the draft position, **Then** the input is empty.
+
+---
+
+### User Story 3 - Terminal "You" Messages Included in History (Priority: P1)
+
+As a user who types prompts directly in the Claude Code or Copilot terminal (rather than through the Argus prompt bar), I want those prompts to also appear in the Argus prompt bar history, so that my full conversation context is navigable from one place.
+
+**Why this priority**: Without this, history is incomplete and misleading. Users who work interleaving terminal input and Argus bar input would see a fragmented, confusing history.
+
+**Independent Test**: Open a session. Type a message directly in the Claude/Copilot terminal (it appears as a "you" message in the session output). Then focus the Argus prompt bar and press up arrow. The terminal-originated message appears in the history. Testable without any Argus-bar sends.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user sent a message from the Claude or Copilot terminal (visible as a "you" message in the session output), **When** the user presses up arrow in the Argus prompt bar, **Then** that terminal-sent message appears in the navigable history.
+2. **Given** both Argus-bar messages and terminal messages have been sent, **When** the user navigates history, **Then** all messages appear in chronological order (oldest first when navigating up, newest first when pressing up initially).
+3. **Given** the same message text appears in both sources within the same session, **Then** each occurrence is treated as a distinct history entry (no deduplication).
+
+---
+
+### Edge Cases
+
+- Up arrow when the prompt input is not focused: default browser behavior (scroll page), not history navigation.
+- The user edits a recalled history entry and sends it: the edited text is stored as a new history entry; the original recalled entry is unchanged.
+- Very long recalled messages: displayed in full in the input field; no truncation.
+- The user navigates history and then sends a recalled message without editing: it is stored as a new entry at the top of history.
+- Terminal messages that arrive after the session view is open are included in history as they appear in the session output.
+- History is per-session and does not mix entries from different sessions.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When the prompt input is focused, pressing the up arrow key MUST replace the current input text with the most recently sent prompt in the current session, regardless of cursor position within the input.
+- **FR-002**: Each subsequent up arrow press MUST replace the input with the next older entry in the session's prompt history.
+- **FR-003**: When the oldest history entry is displayed, further up arrow presses MUST be a no-op (no wrap-around to newest).
+- **FR-004**: When navigating history with down arrow, each press MUST replace the input with the next more-recent entry.
+- **FR-005**: When the user presses down arrow past the most recent history entry, the input MUST restore to the draft text that was present before history navigation began (empty string if the input was empty when navigation started).
+- **FR-006**: Before replacing the input on the first up arrow press, the system MUST save the current input text as a restorable draft.
+- **FR-007**: Prompt history MUST include messages sent via the Argus prompt bar for this session.
+- **FR-008**: Prompt history MUST include messages sent directly from the Claude or Copilot terminal that appear as "you" messages in the session output.
+- **FR-009**: All history entries MUST be presented in chronological order — most recent first when navigating up from the draft position.
+- **FR-010**: Prompt history MUST be scoped to the individual session — entries from other sessions MUST NOT appear.
+- **FR-011**: The system MUST retain at least the 50 most recent prompts per session in history. Entries beyond this limit are silently dropped (oldest first).
+- **FR-012**: Up arrow navigation MUST work regardless of where the cursor is positioned within the prompt input.
+
+### Key Entities
+
+- **Prompt History Entry**: A single user-originated message text associated with a specific session, drawn from either the Argus prompt bar or the session's terminal "you" messages, ordered by the time it was sent.
+- **Draft**: The unsaved text present in the prompt input at the moment the user begins navigating history. Restored when the user navigates past the most recent history entry.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Users can recall and navigate to any of the 10 most recent prompts in a session using only the up/down arrow keys, with no mouse interaction required.
+- **SC-002**: Draft text is preserved and restored with 100% fidelity — no characters lost or altered after a navigate-and-return cycle.
+- **SC-003**: Terminal "you" messages are visible in history within 1 navigation press of Argus-bar messages sent at the same point in the conversation.
+- **SC-004**: History navigation responds within 100 ms per key press — users experience it as instantaneous.
+- **SC-005**: 100% of sessions where the user has sent prompts (via bar or terminal) show those prompts in the navigable history.
+
+## Assumptions
+
+- Prompt history is maintained in-memory for the duration of the browser session; it is not persisted to disk or across page reloads.
+- A cap of 50 entries per session is sufficient for typical usage; no user-facing setting to adjust this limit is provided in this feature.
+- "You" messages from the terminal are identified as session output entries where the role is "user" and the type is "message" — the same entries already displayed as "you" bubbles in the session detail view.
+- Duplicate text entries are not deduplicated — if the user sends the same prompt twice, both appear in history as separate entries.
+- Down arrow outside of history navigation mode (i.e., when at the draft position already) retains default browser input behavior and does not cycle to the oldest entry.
+- History entries from the terminal are available as soon as the session output is received; there is no delay beyond normal session output latency.
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently - e.g., "Can be fully tested by [specific action] and delivers [specific value]"]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+2. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 2 - [Brief Title] (Priority: P2)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 3 - [Brief Title] (Priority: P3)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when [boundary condition]?
+- How does system handle [error scenario]?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
+- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
+- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
+- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
+- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents, key attributes without implementation]
+- **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable metric, e.g., "Users can complete account creation in under 2 minutes"]
+- **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
+- **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
+- **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]
+
+## Assumptions
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right assumptions based on reasonable defaults
+  chosen when the feature description did not specify certain details.
+-->
+
+- [Assumption about target users, e.g., "Users have stable internet connectivity"]
+- [Assumption about scope boundaries, e.g., "Mobile support is out of scope for v1"]
+- [Assumption about data/environment, e.g., "Existing authentication system will be reused"]
+- [Dependency on existing system/service, e.g., "Requires access to the existing user profile API"]

--- a/specs/051-prompt-history/spec.md
+++ b/specs/051-prompt-history/spec.md
@@ -2,7 +2,7 @@
 
 **Feature Branch**: `051-prompt-history`
 **Created**: 2026-04-20
-**Status**: Draft
+**Status**: Clarified
 **Input**: User description: "when i hit the up arrow i want to see the previous requests in this session. The up arrow key can be anywhere in the input. The currently typed text should also be in list of queries. this should be per session. and some user queries can be sent from claude or copilot terminal. they show as you messages and they should also be in the list."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/051-prompt-history/spec.md
+++ b/specs/051-prompt-history/spec.md
@@ -64,8 +64,9 @@ As a user who types prompts directly in the Claude Code or Copilot terminal (rat
 - The user edits a recalled history entry and sends it: the edited text is stored as a new history entry; the original recalled entry is unchanged.
 - Very long recalled messages: displayed in full in the input field; no truncation.
 - The user navigates history and then sends a recalled message without editing: it is stored as a new entry at the top of history.
-- Terminal messages that arrive after the session view is open are included in history as they appear in the session output.
+- Terminal messages that are already in the session output when the Argus view loads are backfilled into history immediately; new terminal messages are added to history as they arrive.
 - History is per-session and does not mix entries from different sessions.
+- The history indicator disappears immediately when the user sends a message or navigates back to the draft position.
 
 ## Requirements *(mandatory)*
 
@@ -78,11 +79,12 @@ As a user who types prompts directly in the Claude Code or Copilot terminal (rat
 - **FR-005**: When the user presses down arrow past the most recent history entry, the input MUST restore to the draft text that was present before history navigation began (empty string if the input was empty when navigation started).
 - **FR-006**: Before replacing the input on the first up arrow press, the system MUST save the current input text as a restorable draft.
 - **FR-007**: Prompt history MUST include messages sent via the Argus prompt bar for this session.
-- **FR-008**: Prompt history MUST include messages sent directly from the Claude or Copilot terminal that appear as "you" messages in the session output.
+- **FR-008**: Prompt history MUST include messages sent directly from the Claude or Copilot terminal that appear as "you" messages in the session output — both messages already present when the Argus view loads (backfilled) and new messages that arrive while the view is open.
 - **FR-009**: All history entries MUST be presented in chronological order — most recent first when navigating up from the draft position.
 - **FR-010**: Prompt history MUST be scoped to the individual session — entries from other sessions MUST NOT appear.
 - **FR-011**: The system MUST retain at least the 50 most recent prompts per session in history. Entries beyond this limit are silently dropped (oldest first).
 - **FR-012**: Up arrow navigation MUST work regardless of where the cursor is positioned within the prompt input.
+- **FR-013**: While the user is navigating history (between first up arrow press and returning to the draft), the prompt bar MUST display a subtle visual indicator showing that history mode is active (for example, an entry index such as "3 / 12" or a "History" label). The indicator MUST disappear when the user returns to the draft position or sends a message.
 
 ### Key Entities
 
@@ -98,6 +100,7 @@ As a user who types prompts directly in the Claude Code or Copilot terminal (rat
 - **SC-003**: Terminal "you" messages are visible in history within 1 navigation press of Argus-bar messages sent at the same point in the conversation.
 - **SC-004**: History navigation responds within 100 ms per key press — users experience it as instantaneous.
 - **SC-005**: 100% of sessions where the user has sent prompts (via bar or terminal) show those prompts in the navigable history.
+- **SC-006**: The history mode indicator appears within 100 ms of the first up arrow press and disappears within 100 ms of returning to the draft position.
 
 ## Assumptions
 
@@ -108,122 +111,9 @@ As a user who types prompts directly in the Claude Code or Copilot terminal (rat
 - Down arrow outside of history navigation mode (i.e., when at the draft position already) retains default browser input behavior and does not cycle to the oldest entry.
 - History entries from the terminal are available as soon as the session output is received; there is no delay beyond normal session output latency.
 
-<!--
-  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
-  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
-  you should still have a viable MVP (Minimum Viable Product) that delivers value.
-  
-  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
-  Think of each story as a standalone slice of functionality that can be:
-  - Developed independently
-  - Tested independently
-  - Deployed independently
-  - Demonstrated to users independently
--->
+## Clarifications
 
-### User Story 1 - [Brief Title] (Priority: P1)
+### Session 2026-04-20
 
-[Describe this user journey in plain language]
-
-**Why this priority**: [Explain the value and why it has this priority level]
-
-**Independent Test**: [Describe how this can be tested independently - e.g., "Can be fully tested by [specific action] and delivers [specific value]"]
-
-**Acceptance Scenarios**:
-
-1. **Given** [initial state], **When** [action], **Then** [expected outcome]
-2. **Given** [initial state], **When** [action], **Then** [expected outcome]
-
----
-
-### User Story 2 - [Brief Title] (Priority: P2)
-
-[Describe this user journey in plain language]
-
-**Why this priority**: [Explain the value and why it has this priority level]
-
-**Independent Test**: [Describe how this can be tested independently]
-
-**Acceptance Scenarios**:
-
-1. **Given** [initial state], **When** [action], **Then** [expected outcome]
-
----
-
-### User Story 3 - [Brief Title] (Priority: P3)
-
-[Describe this user journey in plain language]
-
-**Why this priority**: [Explain the value and why it has this priority level]
-
-**Independent Test**: [Describe how this can be tested independently]
-
-**Acceptance Scenarios**:
-
-1. **Given** [initial state], **When** [action], **Then** [expected outcome]
-
----
-
-[Add more user stories as needed, each with an assigned priority]
-
-### Edge Cases
-
-<!--
-  ACTION REQUIRED: The content in this section represents placeholders.
-  Fill them out with the right edge cases.
--->
-
-- What happens when [boundary condition]?
-- How does system handle [error scenario]?
-
-## Requirements *(mandatory)*
-
-<!--
-  ACTION REQUIRED: The content in this section represents placeholders.
-  Fill them out with the right functional requirements.
--->
-
-### Functional Requirements
-
-- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
-- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
-- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
-- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
-- **FR-005**: System MUST [behavior, e.g., "log all security events"]
-
-*Example of marking unclear requirements:*
-
-- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
-- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
-
-### Key Entities *(include if feature involves data)*
-
-- **[Entity 1]**: [What it represents, key attributes without implementation]
-- **[Entity 2]**: [What it represents, relationships to other entities]
-
-## Success Criteria *(mandatory)*
-
-<!--
-  ACTION REQUIRED: Define measurable success criteria.
-  These must be technology-agnostic and measurable.
--->
-
-### Measurable Outcomes
-
-- **SC-001**: [Measurable metric, e.g., "Users can complete account creation in under 2 minutes"]
-- **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
-- **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
-- **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]
-
-## Assumptions
-
-<!--
-  ACTION REQUIRED: The content in this section represents placeholders.
-  Fill them out with the right assumptions based on reasonable defaults
-  chosen when the feature description did not specify certain details.
--->
-
-- [Assumption about target users, e.g., "Users have stable internet connectivity"]
-- [Assumption about scope boundaries, e.g., "Mobile support is out of scope for v1"]
-- [Assumption about data/environment, e.g., "Existing authentication system will be reused"]
-- [Dependency on existing system/service, e.g., "Requires access to the existing user profile API"]
+- Q: Should terminal "you" messages already in the session output before the Argus view was opened be included in prompt history? → A: Yes — all "you" messages in the session output are backfilled into history when the view loads, plus new ones as they arrive.
+- Q: Should the prompt bar show a visual indicator when the user is actively navigating history? → A: Yes — a subtle inline indicator (e.g., entry index or "History" label) is shown while in history navigation mode.

--- a/specs/051-prompt-history/tasks.md
+++ b/specs/051-prompt-history/tasks.md
@@ -9,8 +9,8 @@
 
 **Purpose**: Create the new hook file and test stubs so downstream tasks have clear targets.
 
-- [ ] T001 Create `frontend/src/hooks/usePromptHistory.ts` with exported stub (empty function, correct TypeScript signature matching `UsePromptHistoryResult` from data-model.md)
-- [ ] T002 Create `frontend/src/__tests__/usePromptHistory.test.ts` with describe block and one placeholder test that asserts the hook exists
+- [x] T001 Create `frontend/src/hooks/usePromptHistory.ts` with exported stub (empty function, correct TypeScript signature matching `UsePromptHistoryResult` from data-model.md)
+- [x] T002 Create `frontend/src/__tests__/usePromptHistory.test.ts` with describe block and one placeholder test that asserts the hook exists
 
 ---
 
@@ -24,25 +24,25 @@
 
 ### Tests for US1+US2
 
-- [ ] T003 [P] [US1] Write failing tests in `usePromptHistory.test.ts` for `navigateUp`:
+- [x] T003 [P] [US1] Write failing tests in `usePromptHistory.test.ts` for `navigateUp`:
   - `navigateUp` with empty entries returns empty string (no-op)
   - `navigateUp` with one entry returns that entry; calling again is a no-op
   - `navigateUp` with multiple entries cycles oldest-to-newest correctly
   - `historyIndex` advances correctly with each call
   - `isNavigating` is false before first call, true after
-- [ ] T004 [P] [US1] Write failing tests in `usePromptHistory.test.ts` for `navigateDown`:
+- [x] T004 [P] [US1] Write failing tests in `usePromptHistory.test.ts` for `navigateDown`:
   - `navigateDown` when not navigating is a no-op (returns empty string)
   - `navigateDown` from historyIndex 1 moves to historyIndex 0
   - `navigateDown` from historyIndex 0 returns the saved draft and resets `isNavigating` to false
-- [ ] T005 [P] [US2] Write failing tests in `usePromptHistory.test.ts` for draft preservation:
+- [x] T005 [P] [US2] Write failing tests in `usePromptHistory.test.ts` for draft preservation:
   - Draft text passed to first `navigateUp` call is stored
   - Draft restored when `navigateDown` is called past the newest entry
   - Empty string draft restored correctly
-- [ ] T006 [P] [US1] Write failing tests in `usePromptHistory.test.ts` for `addEntry`:
+- [x] T006 [P] [US1] Write failing tests in `usePromptHistory.test.ts` for `addEntry`:
   - Adds text to entries; `entries.length` increases
   - Caps entries at 50 (oldest dropped when 51st added)
   - Resets `historyIndex` to null and `isNavigating` to false after adding
-- [ ] T007 [P] [US1] Write failing tests in `SessionPromptBar.test.tsx` for arrow key handling:
+- [x] T007 [P] [US1] Write failing tests in `SessionPromptBar.test.tsx` for arrow key handling:
   - Pressing ArrowUp in the input when no history exists: input unchanged
   - Pressing ArrowUp once when one prompt was sent: input shows that prompt
   - Pressing ArrowUp twice: input shows second-most-recent prompt
@@ -51,7 +51,7 @@
 
 ### Implementation for US1+US2
 
-- [ ] T008 [US1] Implement `usePromptHistory` hook in `frontend/src/hooks/usePromptHistory.ts`:
+- [x] T008 [US1] Implement `usePromptHistory` hook in `frontend/src/hooks/usePromptHistory.ts`:
   - State: `entries: string[]`, `historyIndex: number | null`, `draft: string`
   - `navigateUp(currentInput: string): string` — saves draft on first call, returns next older entry
   - `navigateDown(): string` — returns next newer entry, or draft when past newest
@@ -59,7 +59,7 @@
   - `resetNavigation(): void` — resets historyIndex to null
   - Computed: `isNavigating: boolean`, `indicator: string | null`
   - Ensure all hook functions are < 50 lines each (§III)
-- [ ] T009 [US1] Integrate `usePromptHistory` into `SessionPromptBar.tsx`:
+- [x] T009 [US1] Integrate `usePromptHistory` into `SessionPromptBar.tsx`:
   - Call `const history = usePromptHistory(session.id, [])` (empty array for now — US3 fills this)
   - In `handleKeyDown`: handle `ArrowUp` → `e.preventDefault()`, set prompt to `history.navigateUp(prompt)`
   - In `handleKeyDown`: handle `ArrowDown` → prevent default only when `history.isNavigating`, set prompt to `history.navigateDown()`
@@ -79,25 +79,25 @@
 
 ### Tests for US3
 
-- [ ] T010 [P] [US3] Write failing tests in `usePromptHistory.test.ts` for backfill:
+- [x] T010 [P] [US3] Write failing tests in `usePromptHistory.test.ts` for backfill:
   - When `sessionOutputItems` contains "you" messages on initial render, `entries` is seeded with their content in chronological order
   - `isMeta: true` entries are excluded
   - Empty-content entries are excluded
   - Non-user-message entries (role='assistant', type='tool_use') are excluded
-- [ ] T011 [P] [US3] Write failing tests in `usePromptHistory.test.ts` for live sync:
+- [x] T011 [P] [US3] Write failing tests in `usePromptHistory.test.ts` for live sync:
   - When `sessionOutputItems` gains a new "you" message (higher `sequenceNumber`), it is added to `entries`
   - When `sessionOutputItems` gains a new "you" message whose text matches a pending bar-send, it is NOT added again (dedup via `pendingBarSends`)
   - When user sends the same text twice via bar, both bar-sends are tracked and two corresponding session output entries each decrement the count once
 
 ### Implementation for US3
 
-- [ ] T012 [US3] Add `sessionOutputItems: SessionOutput[]` parameter to `usePromptHistory` hook:
+- [x] T012 [US3] Add `sessionOutputItems: SessionOutput[]` parameter to `usePromptHistory` hook:
   - Seed `entries` from `sessionOutputItems` on mount (filter: `role === 'user'`, `type === 'message'`, `!isMeta`, non-empty content, sorted by `sequenceNumber`)
   - Initialize `lastSeenSequence` to the max `sequenceNumber` among seeded items (or 0)
   - Add `pendingBarSends: Map<string, number>` state
   - Update `addEntry` to increment `pendingBarSends[text]` before appending to entries
   - Add `useEffect` watching `sessionOutputItems`: for each item with `sequenceNumber > lastSeenSequence`, apply dedup logic (decrement `pendingBarSends` if pending, else append to `entries`); update `lastSeenSequence`
-- [ ] T013 [US3] Add `useQuery(['session-output', session.id])` to `SessionPromptBar.tsx`:
+- [x] T013 [US3] Add `useQuery(['session-output', session.id])` to `SessionPromptBar.tsx`:
   - Pass the resulting `data.items ?? []` as second argument to `usePromptHistory`
   - Import `getSessionOutput` and `SessionOutput` (query uses shared cache; no extra network request)
 
@@ -115,12 +115,12 @@
 
 ### Tests for Indicator
 
-- [ ] T014 [P] Write failing tests in `usePromptHistory.test.ts` for `indicator`:
+- [x] T014 [P] Write failing tests in `usePromptHistory.test.ts` for `indicator`:
   - `indicator` is null when not navigating
   - `indicator` is `"1 / N"` after first up arrow (at most recent entry)
   - `indicator` is `"N / N"` at oldest entry
   - `indicator` returns to null after navigating back to draft (down past newest)
-- [ ] T015 [P] Write failing tests in `SessionPromptBar.test.tsx` for indicator rendering:
+- [x] T015 [P] Write failing tests in `SessionPromptBar.test.tsx` for indicator rendering:
   - Indicator element is not present initially
   - Indicator element appears in the DOM after pressing ArrowUp (with correct text)
   - Indicator disappears after pressing ArrowDown back to draft position
@@ -128,8 +128,8 @@
 
 ### Implementation for Indicator
 
-- [ ] T016 Confirm `indicator` computed value in `usePromptHistory` — `historyIndex === null ? null : \`${historyIndex + 1} / ${entries.length}\``; already part of T008, add if missing
-- [ ] T017 Render indicator in `SessionPromptBar.tsx`:
+- [x] T016 Confirm `indicator` computed value in `usePromptHistory` — `historyIndex === null ? null : \`${historyIndex + 1} / ${entries.length}\``; already part of T008, add if missing
+- [x] T017 Render indicator in `SessionPromptBar.tsx`:
   - When `history.indicator` is non-null, render `<span aria-live="polite" className="text-xs text-gray-500 shrink-0 tabular-nums">{history.indicator}</span>` inside the flex row, to the left of the `<input>`
   - Ensure `aria-live="polite"` so screen readers announce navigation position changes
 
@@ -141,9 +141,9 @@
 
 **Purpose**: README update, build validation, full test run.
 
-- [ ] T018 Update `README.md` — add a "Prompt History Navigation" entry under the session prompt bar section, describing the up/down arrow feature, the 50-entry cap, and that terminal messages are included (§XI)
-- [ ] T019 [P] Run `npm run build --workspace=frontend` — confirm no TypeScript errors or build failures
-- [ ] T020 [P] Run `npm run test --workspace=frontend` — confirm all tests pass with no regressions
+- [x] T018 Update `README.md` — add a "Prompt History Navigation" entry under the session prompt bar section, describing the up/down arrow feature, the 50-entry cap, and that terminal messages are included (§XI)
+- [x] T019 [P] Run `npm run build --workspace=frontend` — confirm no TypeScript errors or build failures
+- [x] T020 [P] Run `npm run test --workspace=frontend` — confirm all tests pass with no regressions
 
 ---
 

--- a/specs/051-prompt-history/tasks.md
+++ b/specs/051-prompt-history/tasks.md
@@ -1,0 +1,181 @@
+# Tasks: Session Prompt History Navigation
+
+**Input**: Design documents from `specs/051-prompt-history/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create the new hook file and test stubs so downstream tasks have clear targets.
+
+- [ ] T001 Create `frontend/src/hooks/usePromptHistory.ts` with exported stub (empty function, correct TypeScript signature matching `UsePromptHistoryResult` from data-model.md)
+- [ ] T002 Create `frontend/src/__tests__/usePromptHistory.test.ts` with describe block and one placeholder test that asserts the hook exists
+
+---
+
+## Phase 2: User Story 1 + 2 — Up/Down Navigation with Draft Preservation (Priority: P1)
+
+**Goal**: User can press up arrow to cycle backward through bar-sent prompts and down arrow to cycle forward; the draft text is saved and restored when navigating past the newest entry.
+
+**Independent Test**: Type text in the prompt bar, press up — most recent sent prompt appears. Press up again — older prompt. Press down past newest — original draft text returns exactly. Works with empty draft too.
+
+**⚠️ Write tests FIRST — ensure they FAIL before implementing.**
+
+### Tests for US1+US2
+
+- [ ] T003 [P] [US1] Write failing tests in `usePromptHistory.test.ts` for `navigateUp`:
+  - `navigateUp` with empty entries returns empty string (no-op)
+  - `navigateUp` with one entry returns that entry; calling again is a no-op
+  - `navigateUp` with multiple entries cycles oldest-to-newest correctly
+  - `historyIndex` advances correctly with each call
+  - `isNavigating` is false before first call, true after
+- [ ] T004 [P] [US1] Write failing tests in `usePromptHistory.test.ts` for `navigateDown`:
+  - `navigateDown` when not navigating is a no-op (returns empty string)
+  - `navigateDown` from historyIndex 1 moves to historyIndex 0
+  - `navigateDown` from historyIndex 0 returns the saved draft and resets `isNavigating` to false
+- [ ] T005 [P] [US2] Write failing tests in `usePromptHistory.test.ts` for draft preservation:
+  - Draft text passed to first `navigateUp` call is stored
+  - Draft restored when `navigateDown` is called past the newest entry
+  - Empty string draft restored correctly
+- [ ] T006 [P] [US1] Write failing tests in `usePromptHistory.test.ts` for `addEntry`:
+  - Adds text to entries; `entries.length` increases
+  - Caps entries at 50 (oldest dropped when 51st added)
+  - Resets `historyIndex` to null and `isNavigating` to false after adding
+- [ ] T007 [P] [US1] Write failing tests in `SessionPromptBar.test.tsx` for arrow key handling:
+  - Pressing ArrowUp in the input when no history exists: input unchanged
+  - Pressing ArrowUp once when one prompt was sent: input shows that prompt
+  - Pressing ArrowUp twice: input shows second-most-recent prompt
+  - Pressing ArrowDown after navigating up: input moves toward newest
+  - Pressing ArrowDown past newest: input restores to draft text
+
+### Implementation for US1+US2
+
+- [ ] T008 [US1] Implement `usePromptHistory` hook in `frontend/src/hooks/usePromptHistory.ts`:
+  - State: `entries: string[]`, `historyIndex: number | null`, `draft: string`
+  - `navigateUp(currentInput: string): string` — saves draft on first call, returns next older entry
+  - `navigateDown(): string` — returns next newer entry, or draft when past newest
+  - `addEntry(text: string): void` — appends entry (cap 50), resets navigation
+  - `resetNavigation(): void` — resets historyIndex to null
+  - Computed: `isNavigating: boolean`, `indicator: string | null`
+  - Ensure all hook functions are < 50 lines each (§III)
+- [ ] T009 [US1] Integrate `usePromptHistory` into `SessionPromptBar.tsx`:
+  - Call `const history = usePromptHistory(session.id, [])` (empty array for now — US3 fills this)
+  - In `handleKeyDown`: handle `ArrowUp` → `e.preventDefault()`, set prompt to `history.navigateUp(prompt)`
+  - In `handleKeyDown`: handle `ArrowDown` → prevent default only when `history.isNavigating`, set prompt to `history.navigateDown()`
+  - In `handleSend` (after `await sendPrompt`): call `history.addEntry(text)` with the trimmed text that was sent
+
+**Checkpoint**: US1+US2 fully functional and tested. User can navigate bar-sent prompts with up/down; draft preserved.
+
+---
+
+## Phase 3: User Story 3 — Terminal "You" Messages in History (Priority: P1)
+
+**Goal**: Messages typed directly in the Claude/Copilot terminal (appearing as "you" messages in session output) are also navigable from the Argus prompt bar history, including messages present when the view loads (backfill).
+
+**Independent Test**: Open a session. Type a message in the terminal (not via the bar). Focus the Argus prompt bar, press up arrow. The terminal message appears in the navigable history.
+
+**⚠️ Write tests FIRST — ensure they FAIL before implementing.**
+
+### Tests for US3
+
+- [ ] T010 [P] [US3] Write failing tests in `usePromptHistory.test.ts` for backfill:
+  - When `sessionOutputItems` contains "you" messages on initial render, `entries` is seeded with their content in chronological order
+  - `isMeta: true` entries are excluded
+  - Empty-content entries are excluded
+  - Non-user-message entries (role='assistant', type='tool_use') are excluded
+- [ ] T011 [P] [US3] Write failing tests in `usePromptHistory.test.ts` for live sync:
+  - When `sessionOutputItems` gains a new "you" message (higher `sequenceNumber`), it is added to `entries`
+  - When `sessionOutputItems` gains a new "you" message whose text matches a pending bar-send, it is NOT added again (dedup via `pendingBarSends`)
+  - When user sends the same text twice via bar, both bar-sends are tracked and two corresponding session output entries each decrement the count once
+
+### Implementation for US3
+
+- [ ] T012 [US3] Add `sessionOutputItems: SessionOutput[]` parameter to `usePromptHistory` hook:
+  - Seed `entries` from `sessionOutputItems` on mount (filter: `role === 'user'`, `type === 'message'`, `!isMeta`, non-empty content, sorted by `sequenceNumber`)
+  - Initialize `lastSeenSequence` to the max `sequenceNumber` among seeded items (or 0)
+  - Add `pendingBarSends: Map<string, number>` state
+  - Update `addEntry` to increment `pendingBarSends[text]` before appending to entries
+  - Add `useEffect` watching `sessionOutputItems`: for each item with `sequenceNumber > lastSeenSequence`, apply dedup logic (decrement `pendingBarSends` if pending, else append to `entries`); update `lastSeenSequence`
+- [ ] T013 [US3] Add `useQuery(['session-output', session.id])` to `SessionPromptBar.tsx`:
+  - Pass the resulting `data.items ?? []` as second argument to `usePromptHistory`
+  - Import `getSessionOutput` and `SessionOutput` (query uses shared cache; no extra network request)
+
+**Checkpoint**: US3 complete. All three user stories functional.
+
+---
+
+## Phase 4: History Mode Indicator (FR-013)
+
+**Goal**: While the user is navigating history, a subtle "N / Total" indicator is displayed in the prompt bar. It disappears when the user returns to draft or sends a message.
+
+**Independent Test**: Send 3 prompts. Press up arrow once — indicator shows "1 / 3". Press up again — "2 / 3". Press down to "1 / 3". Press down once more — indicator disappears.
+
+**⚠️ Write tests FIRST — ensure they FAIL before implementing.**
+
+### Tests for Indicator
+
+- [ ] T014 [P] Write failing tests in `usePromptHistory.test.ts` for `indicator`:
+  - `indicator` is null when not navigating
+  - `indicator` is `"1 / N"` after first up arrow (at most recent entry)
+  - `indicator` is `"N / N"` at oldest entry
+  - `indicator` returns to null after navigating back to draft (down past newest)
+- [ ] T015 [P] Write failing tests in `SessionPromptBar.test.tsx` for indicator rendering:
+  - Indicator element is not present initially
+  - Indicator element appears in the DOM after pressing ArrowUp (with correct text)
+  - Indicator disappears after pressing ArrowDown back to draft position
+  - Indicator disappears after sending a message
+
+### Implementation for Indicator
+
+- [ ] T016 Confirm `indicator` computed value in `usePromptHistory` — `historyIndex === null ? null : \`${historyIndex + 1} / ${entries.length}\``; already part of T008, add if missing
+- [ ] T017 Render indicator in `SessionPromptBar.tsx`:
+  - When `history.indicator` is non-null, render `<span aria-live="polite" className="text-xs text-gray-500 shrink-0 tabular-nums">{history.indicator}</span>` inside the flex row, to the left of the `<input>`
+  - Ensure `aria-live="polite"` so screen readers announce navigation position changes
+
+**Checkpoint**: Indicator complete. All acceptance criteria and success criteria (SC-006) met.
+
+---
+
+## Phase 5: Polish and Cross-Cutting Concerns
+
+**Purpose**: README update, build validation, full test run.
+
+- [ ] T018 Update `README.md` — add a "Prompt History Navigation" entry under the session prompt bar section, describing the up/down arrow feature, the 50-entry cap, and that terminal messages are included (§XI)
+- [ ] T019 [P] Run `npm run build --workspace=frontend` — confirm no TypeScript errors or build failures
+- [ ] T020 [P] Run `npm run test --workspace=frontend` — confirm all tests pass with no regressions
+
+---
+
+## Dependencies and Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (US1+US2)**: Depends on Phase 1
+- **Phase 3 (US3)**: Depends on Phase 2 (hook must exist before adding `sessionOutputItems` parameter)
+- **Phase 4 (Indicator)**: Depends on Phase 2 (hook computed values must exist)
+- **Phase 5 (Polish)**: Depends on Phases 2, 3, 4
+
+### Within Phase 2
+
+- Tests (T003–T007) are all independent and can run in parallel
+- Tests MUST fail before T008–T009 implementation begins (TDD gate)
+- T008 (hook implementation) before T009 (integration into component)
+
+### Within Phase 3
+
+- Tests (T010–T011) are independent and can run in parallel
+- Tests MUST fail before T012–T013 begins
+- T012 (hook update) before T013 (component integration)
+
+### Within Phase 4
+
+- Tests (T014–T015) are independent and can run in parallel
+- Tests MUST fail before T016–T017 begins
+- T016 (hook computed value) before T017 (component render)
+
+### Parallel Opportunities
+
+- All test-writing tasks within a phase (marked [P]) can run in parallel
+- T019 and T020 (build + test) can run in parallel after all implementation phases complete


### PR DESCRIPTION
This sync brings keyboard-driven prompt history navigation to the session prompt bar, a set of dashboard layout jank fixes, and quality-of-life improvements across the UI and tooling.

## Changes

**Frontend: Prompt History Navigation (feature 051)**
- Up/down arrow keys in the session prompt bar now cycle through the last 50 sent prompts, with draft text preserved when navigating back to the newest entry.
- Terminal messages typed directly in the Claude/Copilot terminal ('you' messages) are included in history automatically, including backfill on load and live sync as new messages arrive. Bar-sent prompts are deduplicated so they don't appear twice.
- A compact history position indicator (e.g. '1 / 3') appears inside the input as a right-aligned overlay while navigating, with no layout shift when it appears or disappears.

**Frontend: Dashboard Layout Fixes**
- Fixed layout jank on page load by matching the loading skeleton's pane split (flex ratios and h-screen layout) to the real layout, so the page no longer reflows after data arrives.
- Added min-w-0 to the right pane so OutputPane content cannot overflow its flex allocation and squeeze the session list in collapsed mode.

**Frontend: Settings Panel**
- The About section now displays the running server version (e.g. 'v0.1.9') fetched from /api/health, right-aligned next to the heading.

**Backend**
- Fixed /api/health to read the version from the root package.json instead of backend/package.json (was returning 1.0.0 instead of the correct version).

**UI: Telemetry Banner**
- Improved TelemetryBanner layout and test coverage; added a subtle telemetry nudge in the empty session area.

**Docs and Tooling**
- Backfilled CHANGELOG entries for v0.1.1 through v0.1.9.
- Added an update-changelog Claude command that auto-generates CHANGELOG entries from commits since the last tag.
- README updated to document prompt history navigation and the version display in Settings.

## Commits

- 3ca8a24 fix(merge-gate): add version display tests and update README About section
- 505fc38 fix(dashboard): add min-w-0 to right pane to prevent flex overflow
- fa5a1f1 fix(health): read version from root package.json
- 932da43 feat(settings): show app version in About section
- c10a133 fix(dashboard): match loading skeleton pane split to actual layout to prevent jank
- 39ceb1c fix(dashboard): eliminate layout jank on refresh by matching loading skeleton to h-screen layout
- a864c47 feat: auto-generate CHANGELOG entry as part of /publish-npm flow
- eaa33eb feat(ui): move history indicator inside input as overlay
- 6182da3 feat(ui): dashboard layout improvements
- c627799 fix(merge-gate): align TelemetryBanner test selector with actual button text
- 211c8dc docs: backfill CHANGELOG for v0.1.1 through v0.1.9
- 7a3373d feat(dashboard): refine empty state layout
- 908a57c 051: implement prompt history navigation
- 6b87f65 fix: remove telemetry banner when repos exist
- c3a59a0 feat: show subtle gray nudge and telemetry notice in empty session area
- ce5b0f4 chore: bump version to 0.1.9

## Commits

- 3ca8a24 fix(merge-gate): add version display tests and update README About section
- 505fc38 fix(dashboard): add min-w-0 to right pane to prevent flex overflow
- fa5a1f1 fix(health): read version from root package.json
- 932da43 feat(settings): show app version in About section
- c10a133 fix(dashboard): match loading skeleton pane split to actual layout to prevent jank
- 39ceb1c fix(dashboard): eliminate layout jank on refresh by matching loading skeleton to h-screen layout
- a864c47 feat: auto-generate CHANGELOG entry as part of /publish-npm flow
- eaa33eb feat(ui): move history indicator inside input as overlay
- 6182da3 feat(ui): dashboard layout improvements
- c627799 fix(merge-gate): align TelemetryBanner test selector with actual button text (no question mark)
- 211c8dc docs: backfill CHANGELOG for v0.1.1 through v0.1.9
- 7a3373d feat(dashboard): refine empty state layout
- 908a57c 051: implement prompt history navigation
- 42377a5 051: add tasks
- e4437b5 051: add plan, research, data-model
- a99fae5 051: clarify terminal message backfill and history mode indicator
- b165898 051: spec for session prompt history navigation via up/down arrow keys
- 6b87f65 fix: remove telemetry banner when repos exist
- c3a59a0 feat: show subtle gray nudge and telemetry notice in empty session area
- ce5b0f4 chore: bump version to 0.1.9