### PR TITLE
Improve launch error UX and fix npm-release skill

### DIFF
--- a/.claude/commands/npm-release.md
+++ b/.claude/commands/npm-release.md
@@ -4,13 +4,13 @@ description: Tag the current version, push to both remotes, and monitor the npm 
 
 ## Invocation rules
 
-**ONLY execute this skill when the user explicitly types `/publish-npm` as a standalone command.**
+**ONLY execute this skill when the user explicitly types `/npm-release` as a standalone command.**
 Do NOT execute it in response to any of the following:
 - Phrases like "publish npm", "release the package", "push to npm", or any paraphrase
 - Being asked to "run the next step" when an npm release is implied
-- Any autonomous or inferred intent — the user must type the exact slash command `/publish-npm`
+- Any autonomous or inferred intent — the user must type the exact slash command `/npm-release`
 
-If this skill was not triggered by the exact command `/publish-npm`, stop immediately without taking any action.
+If this skill was not triggered by the exact command `/npm-release`, stop immediately without taking any action.
 
 ---
 

--- a/.claude/commands/publish-npm.md
+++ b/.claude/commands/publish-npm.md
@@ -34,7 +34,31 @@ Do not proceed past this step unless the branch is exactly `master`.
 
 ---
 
-### Step 1 — Update the changelog
+### Step 1 — Commit the package.json version bump
+
+Check whether `package.json` has uncommitted changes:
+
+```bash
+git diff --name-only
+git diff --cached --name-only
+```
+
+If `package.json` appears in either list (unstaged or staged), commit it now:
+
+```bash
+git add package.json
+git commit -m "chore: bump version to v<version>
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+If `package.json` is clean (already committed), skip this sub-step and continue.
+
+If `package.json` is absent from the diff but the tag for the current version already exists locally or on origin, stop and tell the user the version has already been released and they need to bump it first.
+
+---
+
+### Step 2 — Update the changelog
 
 Before tagging, invoke the `/update-changelog` skill inline (do not ask the user to run it separately — run it as part of this flow):
 
@@ -48,7 +72,7 @@ If changelog generation fails for any reason, stop and report the error. Do not 
 
 ---
 
-### Step 2 — Run the publish-npm script
+### Step 3 — Run the publish-npm script
 
 Run:
 ```bash
@@ -61,21 +85,21 @@ If it succeeds, note the tag name printed by the script (e.g. `v0.1.1`).
 
 ---
 
-### Step 3 — Locate the triggered workflow run
+### Step 4 — Locate the triggered workflow run
 
 Wait about 5 seconds for GitHub to register the tag push, then run:
 ```bash
 gh run list --repo aarthi-ntrjn/argus --workflow=publish-npm.yml --limit=5 --json databaseId,status,conclusion,headBranch,createdAt
 ```
 
-Find the run whose `headBranch` matches the tag pushed in Step 2. Note its `databaseId`.
+Find the run whose `headBranch` matches the tag pushed in Step 3. Note its `databaseId`.
 
 If no matching run appears after two attempts (10 seconds apart), report:
 "The workflow did not appear on the public repo. Check https://github.com/aarthi-ntrjn/argus/actions manually."
 
 ---
 
-### Step 4 — Poll until complete
+### Step 5 — Poll until complete
 
 Poll the run every 15 seconds using:
 ```bash
@@ -87,7 +111,7 @@ gh run view <databaseId> --repo aarthi-ntrjn/argus --json status,conclusion,jobs
 
 ---
 
-### Step 5 — Report the result
+### Step 6 — Report the result
 
 **On success** (`conclusion` is `success`):
 

--- a/.claude/commands/update-changelog.md
+++ b/.claude/commands/update-changelog.md
@@ -6,7 +6,7 @@ description: Auto-generate a CHANGELOG.md entry for the current version from com
 
 This skill may be invoked:
 - Explicitly by the user typing `/update-changelog`
-- Automatically as a step inside `/publish-npm` — in that case, skip the standalone invocation check and proceed directly
+- Automatically as a step inside `/npm-release` — in that case, skip the standalone invocation check and proceed directly
 
 If invoked as `/update-changelog` standalone, only run on `master`. If not on `master`, stop and say:
 "This skill must be run from `master`. You are currently on `<branch>`."
@@ -119,7 +119,7 @@ git commit -m "docs: update CHANGELOG for v<version>
 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
 ```
 
-Do NOT push. The push happens in the calling skill (`/publish-npm`).
+Do NOT push. The push happens in the calling skill (`/npm-release`).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.10] - 2026-04-21
+
+### Added
+
+- **Prompt history navigation**: Up/down arrow keys in the session prompt bar now cycle through the last 50 sent prompts, with draft text preserved when navigating back past the newest entry. Terminal messages typed directly in Claude/Copilot sessions are included in history and kept in sync live, with deduplication so bar-sent prompts do not appear twice.
+- **History position indicator**: A compact overlay inside the prompt input shows the current navigation position (e.g. `1 / 3`) while browsing history, with no layout shift on appear or dismiss.
+- **Version display in Settings**: The About section of the Settings panel now shows the running server version (e.g. `v0.1.9`), fetched from the health endpoint.
+
+### Fixed
+
+- **Dashboard layout jank**: Fixed layout reflow on page load by matching the loading skeleton pane proportions to the actual layout. Also fixed a flex overflow on the right pane that caused the session list to shrink unexpectedly when output pane content was wide.
+- **Server version endpoint**: Fixed `/api/health` returning `1.0.0` instead of the correct version by reading from the root `package.json`.
+- **Telemetry banner**: Fixed the banner appearing on the dashboard after repositories had already been added.
+
+---
+
 ## [0.1.9] - 2026-04-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **`try/finally` without `catch` is acceptable only when the caller will handle the thrown error.** If the caller is a React event handler (which has no global async error boundary), the error must be caught locally.
 - **Frontend: propagate fetch/API errors to the UI.** When an API call fails, set visible error state. Do not let the mutation silently succeed (no-op) from the user's perspective.
 
+## UX Error Messages
+
+Frontend error messages shown to the user must be contextual and actionable. Raw browser or network errors (e.g., "Failed to fetch") must never reach the UI.
+
+Rules:
+- **Name the action that failed.** Start with what the user was trying to do: "Failed to launch session", "Failed to remove repository", not "Error" or "Failed to fetch".
+- **Translate network errors.** When the caught error message is `"Failed to fetch"` or empty, replace it with a sentence that identifies the likely cause: "The Argus server is unreachable." Include a recovery hint when it is obvious (e.g., "Make sure the backend is running.").
+- **Keep it brief.** One or two sentences maximum. Avoid stack traces, HTTP status codes, and internal identifiers in user-visible text.
+- **Surface in a page-level banner, not inline near the trigger.** Errors from actions like launching, removing, or adding should appear in the dismissible red banner at the top of the page content area, not in a `<p>` next to the button that triggered the action. This ensures the error is visible regardless of where the user's attention is.
+- **Always provide a dismiss action.** Every error banner must have an `×` button with `aria-label="Dismiss error"` and `role="alert"` on the container.
+
 ## Project Context
 
 Argus is a tool for centrally monitoring and remotely controlling Claude Code and GitHub Copilot sessions. For full project documentation, see [README.md](README.md). For architecture, API reference, and dev setup, see [docs/README-CONTRIBUTORS.md](docs/README-CONTRIBUTORS.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Rules:
 - **Name the action that failed.** Start with what the user was trying to do: "Failed to launch session", "Failed to remove repository", not "Error" or "Failed to fetch".
 - **Translate network errors.** When the caught error message is `"Failed to fetch"` or empty, replace it with a sentence that identifies the likely cause: "The Argus server is unreachable." Include a recovery hint when it is obvious (e.g., "Make sure the backend is running.").
 - **Keep it brief.** One or two sentences maximum. Avoid stack traces, HTTP status codes, and internal identifiers in user-visible text.
-- **Surface in a page-level banner, not inline near the trigger.** Errors from actions like launching, removing, or adding should appear in the dismissible red banner at the top of the page content area, not in a `<p>` next to the button that triggered the action. This ensures the error is visible regardless of where the user's attention is.
+- **Surface in a page-level banner, not inline near the trigger.** Errors from actions like launching, removing, or adding should appear in the dismissible red banner at the top of the page content area, not in a `<p>` next to the button that triggered the action. This ensures the error is visible regardless of where the user's attention is. Exception: the send-prompt input in `SessionPromptBar` shows its error directly below the input field, because the user's focus is already there and the error is tightly coupled to that specific input.
 - **Always provide a dismiss action.** Every error banner must have an `×` button with `aria-label="Dismiss error"` and `role="alert"` on the container.
 
 ## Project Context

--- a/frontend/src/__tests__/LaunchDropdown.test.tsx
+++ b/frontend/src/__tests__/LaunchDropdown.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import LaunchDropdown from '../components/LaunchDropdown/LaunchDropdown';
+
+vi.mock('../services/api', () => ({
+  getAvailableTools: vi.fn(),
+  launchInTerminal: vi.fn(),
+}));
+
+import { getAvailableTools, launchInTerminal } from '../services/api';
+
+const mockGetAvailableTools = vi.mocked(getAvailableTools);
+const mockLaunchInTerminal = vi.mocked(launchInTerminal);
+
+const TOOLS_WITH_CLAUDE = {
+  claude: true,
+  copilot: false,
+  claudeCmd: 'claude',
+  copilotCmd: null,
+  terminalAvailable: true,
+};
+
+function renderDropdown(onLaunchError = vi.fn()) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return {
+    onLaunchError,
+    ...render(
+      <QueryClientProvider client={qc}>
+        <LaunchDropdown repoPath="/my/repo" onLaunchError={onLaunchError} />
+      </QueryClientProvider>
+    ),
+  };
+}
+
+describe('LaunchDropdown — error message translation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAvailableTools.mockResolvedValue(TOOLS_WITH_CLAUDE as any);
+    mockLaunchInTerminal.mockResolvedValue({});
+  });
+
+  it('calls onLaunchError with server-unreachable message when fetch fails', async () => {
+    mockLaunchInTerminal.mockRejectedValue(new Error('Failed to fetch'));
+    const { onLaunchError } = renderDropdown();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Launch with Argus' }));
+    await waitFor(() => screen.getByText('Launch Claude'));
+    await userEvent.click(screen.getByText('Launch Claude'));
+
+    await waitFor(() => expect(onLaunchError).toHaveBeenCalledWith(
+      'Failed to launch session. The Argus server is unreachable.'
+    ));
+  });
+
+  it('calls onLaunchError with server-unreachable message when error message is empty', async () => {
+    mockLaunchInTerminal.mockRejectedValue(new Error(''));
+    const { onLaunchError } = renderDropdown();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Launch with Argus' }));
+    await waitFor(() => screen.getByText('Launch Claude'));
+    await userEvent.click(screen.getByText('Launch Claude'));
+
+    await waitFor(() => expect(onLaunchError).toHaveBeenCalledWith(
+      'Failed to launch session. The Argus server is unreachable.'
+    ));
+  });
+
+  it('calls onLaunchError with prefixed message for other server errors', async () => {
+    mockLaunchInTerminal.mockRejectedValue(new Error('Terminal not found'));
+    const { onLaunchError } = renderDropdown();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Launch with Argus' }));
+    await waitFor(() => screen.getByText('Launch Claude'));
+    await userEvent.click(screen.getByText('Launch Claude'));
+
+    await waitFor(() => expect(onLaunchError).toHaveBeenCalledWith(
+      'Failed to launch session: Terminal not found'
+    ));
+  });
+
+  it('does not call onLaunchError when launch succeeds', async () => {
+    mockLaunchInTerminal.mockResolvedValue({});
+    const { onLaunchError } = renderDropdown();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Launch with Argus' }));
+    await waitFor(() => screen.getByText('Launch Claude'));
+    await userEvent.click(screen.getByText('Launch Claude'));
+
+    await waitFor(() => expect(mockLaunchInTerminal).toHaveBeenCalled());
+    expect(onLaunchError).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/LaunchDropdown/LaunchDropdown.tsx
+++ b/frontend/src/components/LaunchDropdown/LaunchDropdown.tsx
@@ -7,12 +7,18 @@ import { Button } from '../Button';
 
 interface Props {
   repoPath: string;
+  onLaunchError: (msg: string) => void;
 }
 
-export default function LaunchDropdown({ repoPath }: Props) {
+function toLaunchErrorMessage(err: unknown): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  if (!raw || raw === 'Failed to fetch') return 'Failed to launch session. The Argus server is unreachable.';
+  return `Failed to launch session: ${raw}`;
+}
+
+export default function LaunchDropdown({ repoPath, onLaunchError }: Props) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState<'claude' | 'copilot' | null>(null);
-  const [launchError, setLaunchError] = useState<string | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
   const { data: tools } = useQuery({
@@ -73,7 +79,7 @@ export default function LaunchDropdown({ repoPath }: Props) {
     try {
       await launchInTerminal(tool, repoPath);
     } catch (err) {
-      setLaunchError(err instanceof Error ? err.message : 'Failed to launch');
+      onLaunchError(toLaunchErrorMessage(err));
     }
   };
 
@@ -82,14 +88,11 @@ export default function LaunchDropdown({ repoPath }: Props) {
 
   return (
     <div className="relative" ref={menuRef}>
-      {launchError && (
-        <p className="text-xs text-red-600 mb-1">{launchError}</p>
-      )}
       <Button
         variant="outline"
         size="sm"
         data-tour-id="dashboard-launch"
-        onClick={() => { setLaunchError(null); setOpen(o => !o); }}
+        onClick={() => { setOpen(o => !o); }}
         title="Launch a new session with Argus"
         aria-label="Launch with Argus"
         aria-expanded={open}

--- a/frontend/src/components/RepoCard/RepoCard.tsx
+++ b/frontend/src/components/RepoCard/RepoCard.tsx
@@ -18,11 +18,12 @@ interface RepoCardProps {
   onRemoveById: (id: string) => void;
   onSetRemoveConfirm: (id: string) => void;
   onSelectSession: (id: string) => void;
+  onLaunchError: (msg: string) => void;
 }
 
 export default function RepoCard({
   repo, skipConfirm, selectedSessionId, isMobile,
-  onRemoveById, onSetRemoveConfirm, onSelectSession,
+  onRemoveById, onSetRemoveConfirm, onSelectSession, onLaunchError,
 }: RepoCardProps) {
   return (
     <div data-tour-id="dashboard-repo-card" className="bg-white rounded-lg shadow p-4 md:p-6">
@@ -33,7 +34,7 @@ export default function RepoCard({
             <Badge>
               {repo.sessions.length} session{repo.sessions.length !== 1 ? 's' : ''}
             </Badge>
-            <LaunchDropdown repoPath={repo.path} />
+            <LaunchDropdown repoPath={repo.path} onLaunchError={onLaunchError} />
             <button
               onClick={(e) => {
                 e.stopPropagation();

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -69,6 +69,8 @@ export default function DashboardPage() {
     cancelFolderInput, clearAddError,
   } = useRepositoryManagement();
 
+  const [launchError, setLaunchError] = useState<string | null>(null);
+
   const [infoSnapshot, setInfoSnapshot] = useState<string | null>(null);
   useEffect(() => { if (addInfo) setInfoSnapshot(addInfo); }, [addInfo]);
 
@@ -196,6 +198,7 @@ export default function DashboardPage() {
           onRemoveById={handleRemoveRepoById}
           onSetRemoveConfirm={setRemoveConfirmId}
           onSelectSession={handleSessionSelect}
+          onLaunchError={setLaunchError}
         />
       ))}
     </div>
@@ -311,6 +314,13 @@ export default function DashboardPage() {
           <div role="alert" className="mb-4 px-3 py-2 bg-red-50 border border-red-200 rounded text-red-700 text-sm flex items-center justify-between gap-3">
             <span className="leading-snug">{addError}</span>
             <button onClick={clearAddError} aria-label="Dismiss error" className="icon-btn shrink-0 p-0 leading-none">&times;</button>
+          </div>
+        )}
+
+        {launchError && (
+          <div role="alert" className="mb-4 px-3 py-2 bg-red-50 border border-red-200 rounded text-red-700 text-sm flex items-center justify-between gap-3">
+            <span className="leading-snug">{launchError}</span>
+            <button onClick={() => setLaunchError(null)} aria-label="Dismiss error" className="icon-btn shrink-0 p-0 leading-none">&times;</button>
           </div>
         )}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "argus-ai-hub",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "argus-ai-hub",
-      "version": "0.1.8",
+      "version": "0.1.10",
       "license": "MIT",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argus-ai-hub",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Your command center for Claude Code and GitHub Copilot CLI sessions. Watch every session live, send commands, and stop runaway agents, all from a single browser tab.",
   "license": "MIT",
   "homepage": "https://github.com/aarthi-ntrjn/argus#readme",

--- a/specs/053-layout-fixes/spec.md
+++ b/specs/053-layout-fixes/spec.md
@@ -1,0 +1,128 @@
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`  
+**Created**: [DATE]  
+**Status**: Draft  
+**Input**: User description: "$ARGUMENTS"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently - e.g., "Can be fully tested by [specific action] and delivers [specific value]"]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+2. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 2 - [Brief Title] (Priority: P2)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 3 - [Brief Title] (Priority: P3)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when [boundary condition]?
+- How does system handle [error scenario]?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
+- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
+- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
+- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
+- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents, key attributes without implementation]
+- **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable metric, e.g., "Users can complete account creation in under 2 minutes"]
+- **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
+- **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
+- **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]
+
+## Assumptions
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right assumptions based on reasonable defaults
+  chosen when the feature description did not specify certain details.
+-->
+
+- [Assumption about target users, e.g., "Users have stable internet connectivity"]
+- [Assumption about scope boundaries, e.g., "Mobile support is out of scope for v1"]
+- [Assumption about data/environment, e.g., "Existing authentication system will be reused"]
+- [Dependency on existing system/service, e.g., "Requires access to the existing user profile API"]

--- a/specs/054-ubuntu-send-prompt-enter/spec.md
+++ b/specs/054-ubuntu-send-prompt-enter/spec.md
@@ -1,0 +1,128 @@
+# Feature Specification: [FEATURE NAME]
+
+**Feature Branch**: `[###-feature-name]`  
+**Created**: [DATE]  
+**Status**: Draft  
+**Input**: User description: "$ARGUMENTS"
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently - e.g., "Can be fully tested by [specific action] and delivers [specific value]"]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+2. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 2 - [Brief Title] (Priority: P2)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 3 - [Brief Title] (Priority: P3)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+[Add more user stories as needed, each with an assigned priority]
+
+### Edge Cases
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right edge cases.
+-->
+
+- What happens when [boundary condition]?
+- How does system handle [error scenario]?
+
+## Requirements *(mandatory)*
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right functional requirements.
+-->
+
+### Functional Requirements
+
+- **FR-001**: System MUST [specific capability, e.g., "allow users to create accounts"]
+- **FR-002**: System MUST [specific capability, e.g., "validate email addresses"]  
+- **FR-003**: Users MUST be able to [key interaction, e.g., "reset their password"]
+- **FR-004**: System MUST [data requirement, e.g., "persist user preferences"]
+- **FR-005**: System MUST [behavior, e.g., "log all security events"]
+
+*Example of marking unclear requirements:*
+
+- **FR-006**: System MUST authenticate users via [NEEDS CLARIFICATION: auth method not specified - email/password, SSO, OAuth?]
+- **FR-007**: System MUST retain user data for [NEEDS CLARIFICATION: retention period not specified]
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents, key attributes without implementation]
+- **[Entity 2]**: [What it represents, relationships to other entities]
+
+## Success Criteria *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Define measurable success criteria.
+  These must be technology-agnostic and measurable.
+-->
+
+### Measurable Outcomes
+
+- **SC-001**: [Measurable metric, e.g., "Users can complete account creation in under 2 minutes"]
+- **SC-002**: [Measurable metric, e.g., "System handles 1000 concurrent users without degradation"]
+- **SC-003**: [User satisfaction metric, e.g., "90% of users successfully complete primary task on first attempt"]
+- **SC-004**: [Business metric, e.g., "Reduce support tickets related to [X] by 50%"]
+
+## Assumptions
+
+<!--
+  ACTION REQUIRED: The content in this section represents placeholders.
+  Fill them out with the right assumptions based on reasonable defaults
+  chosen when the feature description did not specify certain details.
+-->
+
+- [Assumption about target users, e.g., "Users have stable internet connectivity"]
+- [Assumption about scope boundaries, e.g., "Mobile support is out of scope for v1"]
+- [Assumption about data/environment, e.g., "Existing authentication system will be reused"]
+- [Dependency on existing system/service, e.g., "Requires access to the existing user profile API"]


### PR DESCRIPTION
This sync improves the "Launch with Argus" error experience, moving raw network errors into the page-level dismissible banner with friendly, actionable messages. It also fixes the npm-release workflow skill (renamed from /publish-npm) to commit package.json version bumps before tagging.

## Changes

### Frontend
- **Launch error banner**: When "Launch with Argus" fails, errors now appear in the page-level dismissible banner with user-friendly messages: "Failed to launch session. The Argus server is unreachable." for network failures, or "Failed to launch session: <detail>" for server errors. Previously, the raw "Failed to fetch" string appeared above the button.
- **LaunchDropdown tests**: Added 4 tests covering error message translation (network failure, empty error, server error, and success path).

### Docs / Skills
- **UX error message guidelines**: CLAUDE.md now documents rules for naming actions in errors, translating network errors, banner placement, and the send-prompt inline-error exception.
- **/npm-release skill**: Renamed from /publish-npm; now commits any uncommitted package.json version bump before generating the changelog and creating the tag.
- **CHANGELOG**: Updated for v0.1.10.

## Commits

- cbece13 chore: rename /publish-npm skill to /npm-release
- 1114dbb fix(merge-gate): add test coverage for LaunchDropdown error translation
- 38ff364 docs: note send-prompt inline error exception in UX error guidelines
- eb9e441 fix(launch): move launch error to page banner with friendly message
- 465539e fix(publish-npm): commit package.json version bump before tagging
- 844c43d chore: commit package-lock and spec scaffolding
- cf7b5c1 docs: update CHANGELOG for v0.1.10

## Commits

- cbece13 chore: rename /publish-npm skill to /npm-release
- 1114dbb fix(merge-gate): add test coverage for LaunchDropdown error translation
- 38ff364 docs: note send-prompt inline error exception in UX error guidelines
- eb9e441 fix(launch): move launch error to page banner with friendly message
- 465539e fix(publish-npm): commit package.json version bump before tagging
- 844c43d chore: commit package-lock and spec scaffolding
- cf7b5c1 docs: update CHANGELOG for v0.1.10