### PR TITLE
Fix send-prompt enter key on non-Windows and release v0.1.11

### DIFF
--- a/.claude/commands/publish-to-public.md
+++ b/.claude/commands/publish-to-public.md
@@ -4,13 +4,13 @@ description: Generate a meaningful PR description for the public repo sync, then
 
 ## Invocation rules
 
-**ONLY execute this skill when the user explicitly types `/publish` as a standalone command.**
+**ONLY execute this skill when the user explicitly types `/publish-to-public` as a standalone command.**
 Do NOT execute it in response to any of the following:
 - Phrases like "publish", "sync the public repo", "push to public", or any paraphrase
 - Being asked to "run the next step" when publish is implied
-- Any autonomous or inferred intent — the user must type the exact slash command `/publish`
+- Any autonomous or inferred intent — the user must type the exact slash command `/publish-to-public`
 
-If this skill was not triggered by the exact command `/publish`, stop immediately without taking any action.
+If this skill was not triggered by the exact command `/publish-to-public`, stop immediately without taking any action.
 
 ---
 
@@ -100,4 +100,4 @@ Once the script completes, output:
 - Merged: ✅
 ```
 
-If the script fails (CI failure, merge conflict, etc.), report the error clearly and tell the user what to fix before re-running `/publish`.
+If the script fails (CI failure, merge conflict, etc.), report the error clearly and tell the user what to fix before re-running `/publish-to-public`.

--- a/.claude/commands/push-to-public.md
+++ b/.claude/commands/push-to-public.md
@@ -4,13 +4,13 @@ description: Generate a meaningful PR description for the public repo sync, then
 
 ## Invocation rules
 
-**ONLY execute this skill when the user explicitly types `/publish-to-public` as a standalone command.**
+**ONLY execute this skill when the user explicitly types `/push-to-public` as a standalone command.**
 Do NOT execute it in response to any of the following:
 - Phrases like "publish", "sync the public repo", "push to public", or any paraphrase
 - Being asked to "run the next step" when publish is implied
-- Any autonomous or inferred intent — the user must type the exact slash command `/publish-to-public`
+- Any autonomous or inferred intent — the user must type the exact slash command `/push-to-public`
 
-If this skill was not triggered by the exact command `/publish-to-public`, stop immediately without taking any action.
+If this skill was not triggered by the exact command `/push-to-public`, stop immediately without taking any action.
 
 ---
 
@@ -100,4 +100,5 @@ Once the script completes, output:
 - Merged: ✅
 ```
 
-If the script fails (CI failure, merge conflict, etc.), report the error clearly and tell the user what to fix before re-running `/publish-to-public`.
+If the script fails (CI failure, merge conflict, etc.), report the error clearly and tell the user what to fix before re-running `/push-to-public`.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Launch error messages**: When "Launch with Argus" fails, errors now appear in the page-level dismissible banner with a clear, actionable message (e.g., "Failed to launch session. The Argus server is unreachable.") instead of a raw network error above the button.
 - **Dashboard layout jank**: Fixed layout reflow on page load by matching the loading skeleton pane proportions to the actual layout. Also fixed a flex overflow on the right pane that caused the session list to shrink unexpectedly when output pane content was wide.
 - **Server version endpoint**: Fixed `/api/health` returning `1.0.0` instead of the correct version by reading from the root `package.json`.
 - **Telemetry banner**: Fixed the banner appearing on the dashboard after repositories had already been added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.10] - 2026-04-21
+## [0.1.11] - 2026-04-21
 
 ### Added
 

--- a/backend/src/cli/launch.ts
+++ b/backend/src/cli/launch.ts
@@ -115,39 +115,39 @@ client.setRegisterInfo({ hostPid: pty.pid, pid: isWin ? null : pty.pid, sessionT
 
 // Yield Win32 input mode sequences(ESC[Vk;Sc;Uc;Kd;Cs;Rc_) for a single character,
 // one buffer per event: key-down first, then key-up.
-function* win32InputEvents(ch: string): Generator<Buffer> {
-  // [VirtualKey, ScanCode] for US QWERTY layout
-  const keyInfo: Record<string, [number, number]> = {
-    'a': [65, 30], 'b': [66, 48], 'c': [67, 46], 'd': [68, 32], 'e': [69, 18],
-    'f': [70, 33], 'g': [71, 34], 'h': [72, 35], 'i': [73, 23], 'j': [74, 36],
-    'k': [75, 37], 'l': [76, 38], 'm': [77, 50], 'n': [78, 49], 'o': [79, 24],
-    'p': [80, 25], 'q': [81, 16], 'r': [82, 19], 's': [83, 31], 't': [84, 20],
-    'u': [85, 22], 'v': [86, 47], 'w': [87, 17], 'x': [88, 45], 'y': [89, 21],
-    'z': [90, 44], ' ': [32, 57], '\r': [13, 28],
-    '0': [48, 11], '1': [49, 2], '2': [50, 3], '3': [51, 4], '4': [52, 5],
-    '5': [53, 6], '6': [54, 7], '7': [55, 8], '8': [56, 9], '9': [57, 10],
-    '-': [189, 12], '=': [187, 13], '[': [219, 26], ']': [221, 27],
-    ';': [186, 39], "'": [222, 40], ',': [188, 51], '.': [190, 52], '/': [191, 53],
-  };
-  const lower = ch.toLowerCase();
-  const [vk, sc] = keyInfo[lower] ?? [ch.charCodeAt(0), 0];
-  const uc = ch.charCodeAt(0);
-  yield Buffer.from(`\x1b[${vk};${sc};${uc};1;0;1_`); // key down
-  yield Buffer.from(`\x1b[${vk};${sc};${uc};0;0;1_`); // key up
-}
+// function* win32InputEvents(ch: string): Generator<Buffer> {
+//   // [VirtualKey, ScanCode] for US QWERTY layout
+//   const keyInfo: Record<string, [number, number]> = {
+//     'a': [65, 30], 'b': [66, 48], 'c': [67, 46], 'd': [68, 32], 'e': [69, 18],
+//     'f': [70, 33], 'g': [71, 34], 'h': [72, 35], 'i': [73, 23], 'j': [74, 36],
+//     'k': [75, 37], 'l': [76, 38], 'm': [77, 50], 'n': [78, 49], 'o': [79, 24],
+//     'p': [80, 25], 'q': [81, 16], 'r': [82, 19], 's': [83, 31], 't': [84, 20],
+//     'u': [85, 22], 'v': [86, 47], 'w': [87, 17], 'x': [88, 45], 'y': [89, 21],
+//     'z': [90, 44], ' ': [32, 57], '\r': [13, 28],
+//     '0': [48, 11], '1': [49, 2], '2': [50, 3], '3': [51, 4], '4': [52, 5],
+//     '5': [53, 6], '6': [54, 7], '7': [55, 8], '8': [56, 9], '9': [57, 10],
+//     '-': [189, 12], '=': [187, 13], '[': [219, 26], ']': [221, 27],
+//     ';': [186, 39], "'": [222, 40], ',': [188, 51], '.': [190, 52], '/': [191, 53],
+//   };
+//   const lower = ch.toLowerCase();
+//   const [vk, sc] = keyInfo[lower] ?? [ch.charCodeAt(0), 0];
+//   const uc = ch.charCodeAt(0);
+//   yield Buffer.from(`\x1b[${vk};${sc};${uc};1;0;1_`); // key down
+//   yield Buffer.from(`\x1b[${vk};${sc};${uc};0;0;1_`); // key up
+// }
 
 // Delay between Win32 keystroke pairs so Copilot CLI can process each character
 // before the next arrives. Without this, all pushes land in a single event-loop
 // tick and the PTY drops or merges them.
-const KEYSTROKE_DELAY_MS = 10;
+// const KEYSTROKE_DELAY_MS = 10;
 
 // Push a buffer to stdin then wait KEYSTROKE_DELAY_MS before returning.
 // Every Win32 input event goes through this so the PTY sees a natural
 // inter-event gap and does not drop or merge simultaneous arrivals.
-const pushStdin = (buf: Buffer): Promise<void> => {
-  process.stdin.push(buf);
-  return new Promise<void>((resolve) => setTimeout(resolve, KEYSTROKE_DELAY_MS));
-};
+// const pushStdin = (buf: Buffer): Promise<void> => {
+//   process.stdin.push(buf);
+//   return new Promise<void>((resolve) => setTimeout(resolve, KEYSTROKE_DELAY_MS));
+// };
 
 // sendPromptV1: Win32 keyboard input sequence path.
 // Encodes the prompt as Win32 keyboard input sequences and pushes to stdin.
@@ -155,65 +155,79 @@ const pushStdin = (buf: Buffer): Promise<void> => {
 // process.stdin.push() with Win32 sequences is the correct path.
 // pty.write() does not work for interactive prompts (e.g. AskUserQuestion in
 // claude-code) because the PTY may be in raw/char mode waiting for a single keystroke.
-const sendPromptV1 = async (prompt: string): Promise<void> => {
-  log(`win32 focus-in`);
-  await pushStdin(Buffer.from('\x1b[I'));
-  for (const ch of prompt) {
-    for (const buf of win32InputEvents(ch)) {
-      await pushStdin(buf);
-    }
-  }
-  for (const buf of win32InputEvents('\r')) {
-    await pushStdin(buf);
-  }
-  await pushStdin(Buffer.from('\x1b[O'));
-};
+// const sendPromptV1 = async (prompt: string): Promise<void> => {
+//   log(`win32 focus-in`);
+//   await pushStdin(Buffer.from('\x1b[I'));
+//   for (const ch of prompt) {
+//     for (const buf of win32InputEvents(ch)) {
+//       await pushStdin(buf);
+//     }
+//   }
+//   for (const buf of win32InputEvents('\r')) {
+//     await pushStdin(buf);
+//   }
+//   await pushStdin(Buffer.from('\x1b[O'));
+// };
 
-// sendPromptWin: POSIX pty.write path with inter-write delays.
+// sendPromptInterwriteDelay: pty.write path with inter-write delays.
 // Writes focus-in, the full prompt, then focus-out to the PTY master, pausing
 // 10ms after each write so the app has time to process each sequence before
 // the next one arrives.
 const WRITE_DELAY_MS = 10;
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
-const sendPromptWin = async (prompt: string, skipEnter = false): Promise<void> => {
-  log(`posix focus-in`);
+// const sendPromptInterwriteDelayV1 = async (prompt: string, skipEnter = false): Promise<void> => {
+//   log(`focus-in`);
+//   pty.write('\x1b[I');
+//   await delay(WRITE_DELAY_MS);
+//   log(`pty.write promptLen=${prompt.length}`);
+//   pty.write(prompt);
+//   await delay(WRITE_DELAY_MS);
+//   // skipEnter is true when ask_user|AskUserQuestion tool is being handled
+//   if (!skipEnter) {
+//     // Without this keyboard mimic of '\r', Windows does not recognize the end of the sentence.
+//     for (const buf of win32InputEvents('\r')) {
+//       await pushStdin(buf);
+//     }
+//   }
+//   log(`focus-out`);
+//   pty.write('\x1b[O');
+//   await delay(WRITE_DELAY_MS);
+// };
+
+const sendPromptInterwriteDelayV2 = async (prompt: string, skipEnter = false): Promise<void> => {
+  log(`focus-in`);
   pty.write('\x1b[I');
   await delay(WRITE_DELAY_MS);
-  log(`posix pty.write promptLen=${prompt.length}`);
+  log(`pty.write promptLen=${prompt.length}`);
   pty.write(prompt);
   await delay(WRITE_DELAY_MS);
+  // skipEnter is true when ask_user|AskUserQuestion tool is being handled
   if (!skipEnter) {
     // Without this keyboard mimic of '\r', Windows does not recognize the end of the sentence.
-    for (const buf of win32InputEvents('\r')) {
-      await pushStdin(buf);
-    }
+    pty.write('\r');
   }
-  log(`posix focus-out`);
+  log(`focus-out`);
   pty.write('\x1b[O');
   await delay(WRITE_DELAY_MS);
 };
 
-// sendPromptNoDelay: POSIX pty.write path without inter-write delays.
-const sendPromptNoDelay = (prompt: string): void => {
-  log(`posix focus-in (no-delay)`);
-  pty.write('\x1b[I');
-  log(`posix pty.write promptLen=${prompt.length} (no-delay)`);
-  pty.write(prompt + '\r');
-  log(`posix focus-out (no-delay)`);
-  pty.write('\x1b[O');
-};
+// sendPromptNoDelay: POSIX pty.write path without inter-write delays. Even on POSIX, we are seeing bug where enter is not getting sent.
+// const sendPromptNoDelay = (prompt: string): void => {
+//   log(`posix focus-in (no-delay)`);
+//   pty.write('\x1b[I');
+//   log(`posix pty.write promptLen=${prompt.length} (no-delay)`);
+//   pty.write(prompt + '\r');
+//   log(`posix focus-out (no-delay)`);
+//   pty.write('\x1b[O');
+// };
 
 // When Argus sends a prompt, deliver it to the PTY.
-// On Windows + copilot-cli: use sendPromptWin (inter-write delays required for the Console API).
+// On any OS: use sendPromptInterwriteDelay (inter-write delays required for the Console API).
 // All other cases: use sendPromptNoDelay.
 client.onSendPrompt(async (actionId: string, prompt: string, skipEnter: boolean) => {
   log(`onSendPrompt actionId=${actionId} promptLen=${prompt.length} skipEnter=${skipEnter}`);
   try {
-    if (isWin) {
-      await sendPromptWin(prompt, skipEnter);
-    } else {
-      sendPromptNoDelay(prompt);
-    }
+    await sendPromptInterwriteDelayV2(prompt, skipEnter);    
     client.ackDelivered(actionId);
   } catch (err) {
     log(`prompt delivery failed: ${err}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "argus-ai-hub",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "argus-ai-hub",
-      "version": "0.1.10",
+      "version": "0.1.11",
       "license": "MIT",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argus-ai-hub",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Your command center for Claude Code and GitHub Copilot CLI sessions. Watch every session live, send commands, and stop runaway agents, all from a single browser tab.",
   "license": "MIT",
   "homepage": "https://github.com/aarthi-ntrjn/argus#readme",


### PR DESCRIPTION
This sync fixes a bug where prompts sent via Argus were not triggering the enter key on non-Windows systems. The prompt text arrived in the terminal but the session never processed it because the enter key used a Win32-specific keyboard sequence that only works on Windows. The fix uses pty.write('\r') with the same inter-write delay for all platforms. This sync also includes the v0.1.11 version bump and CHANGELOG updates.

## Changes

### Backend
- **Send-prompt enter key fix**: On non-Windows, the enter key after a sent prompt now uses pty.write('\r') with an inter-write delay instead of Win32 keyboard input sequences, so prompts are processed correctly on Linux and macOS.

### Release
- Version bumped to 0.1.11 with updated CHANGELOG covering all changes since v0.1.9.

### Scripts / Skills
- Renamed internal skill commands for clarity: /publish to /push-to-public, and /publish-npm to /npm-release.

## Commits

- 644debb chore: rename /publish-to-public skill to /push-to-public
- 9f53f36 chore: rename /publish skill to /publish-to-public
- 9a44e07 fix(launch): use pty.write for enter key to fix send-prompt on non-Windows
- 6530828 docs: update CHANGELOG for v0.1.11
- 17c9917 chore: bump version to v0.1.11
- c23a87a docs: update CHANGELOG for v0.1.10

## Commits

- 644debb chore: rename /publish-to-public skill to /push-to-public
- 9f53f36 chore: rename /publish skill to /publish-to-public
- 9a44e07 fix(launch): use pty.write for enter key to fix send-prompt on non-Windows
- 6530828 docs: update CHANGELOG for v0.1.11
- 17c9917 chore: bump version to v0.1.11
- c23a87a docs: update CHANGELOG for v0.1.10