### PR TITLE
Add tilde path support and improve no-tools install guidance

### DIFF
--- a/.claude/commands/bump-version.md
+++ b/.claude/commands/bump-version.md
@@ -1,0 +1,139 @@
+---
+description: Increment package.json version, update CHANGELOG, create an annotated git tag, and push to origin.
+---
+
+## Invocation rules
+
+**ONLY execute this skill when the user explicitly types `/bump-version` as a standalone command.**
+Do NOT execute it in response to any paraphrase or implied intent. The user must type the exact slash command `/bump-version`.
+
+If this skill was not triggered by the exact command `/bump-version`, stop immediately without taking any action.
+
+---
+
+## Outline
+
+You are bumping the version for this project. Follow these steps exactly.
+
+---
+
+### Step 0 — Verify we are on master
+
+Run:
+```
+git branch --show-current
+```
+
+If not on `master`, stop immediately and tell the user:
+"This skill must be run from `master`. You are currently on `<branch>`. Run: `git checkout master` first."
+
+Also verify the working tree is clean:
+```
+git status --porcelain
+```
+
+If there are uncommitted changes (other than `package.json`), stop and tell the user to commit or stash them first.
+
+---
+
+### Step 1 — Determine the bump type
+
+Check `$ARGUMENTS` first. If the user passed a bump type or version as an argument (e.g. `/bump-version patch`, `/bump-version minor`, `/bump-version 1.2.3`), use that directly.
+
+If no argument was provided, ask the user:
+
+```
+Which version bump?
+  1. patch  (bug fixes — x.y.Z)
+  2. minor  (new features — x.Y.0)
+  3. major  (breaking changes — X.0.0)
+  4. custom (enter a specific version)
+```
+
+Wait for the user's choice before proceeding.
+
+---
+
+### Step 2 — Bump package.json
+
+Run `npm version` with `--no-git-tag-version` so npm updates the file without creating a commit or tag (we handle those explicitly):
+
+```bash
+npm version <patch|minor|major|custom-version> --no-git-tag-version
+```
+
+Read back the new version:
+
+```bash
+node -e "console.log(require('./package.json').version)"
+```
+
+The tag will be `v<version>` (e.g. `v1.2.3`).
+
+Check that this tag does not already exist locally or on origin:
+
+```bash
+git tag -l v<version>
+git ls-remote origin "refs/tags/v<version>"
+```
+
+If the tag already exists, stop and report: "Tag v<version> already exists. The version has already been released."
+
+---
+
+### Step 3 — Commit the version bump
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: bump version to v<version>
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Step 4 — Update the changelog
+
+Invoke the `/update-changelog` skill inline (do not ask the user to run it separately):
+
+- Collect commits since the last tag
+- Generate and commit the changelog entry
+
+The changelog commit must exist **before** the tag is created so it is included in the release.
+
+If changelog generation fails for any reason, stop and report the error. Do not proceed to tagging.
+
+---
+
+### Step 5 — Push master to origin
+
+```bash
+git push origin master
+```
+
+This ensures the version bump commit and changelog commit are on origin before the tag points at them.
+
+---
+
+### Step 6 — Create and push the annotated tag
+
+```bash
+git tag -a v<version> -m "Release v<version>"
+git push origin v<version>
+```
+
+---
+
+### Step 7 — Report
+
+Print a summary:
+
+```
+## Version bumped to v<version>
+
+- package.json updated
+- CHANGELOG updated (<N> entries)
+- Tag v<version> created and pushed to origin
+
+Run /npm-release to publish to npm.
+```

--- a/.claude/commands/npm-release.md
+++ b/.claude/commands/npm-release.md
@@ -1,5 +1,5 @@
 ---
-description: Tag the current version, push to both remotes, and monitor the npm publish workflow on the public repo until it succeeds or fails.
+description: Push the current version tag to the public remote and monitor the npm publish workflow until it succeeds or fails.
 ---
 
 ## Invocation rules
@@ -14,9 +14,17 @@ If this skill was not triggered by the exact command `/npm-release`, stop immedi
 
 ---
 
+## Prerequisite
+
+**Run `/bump-version` before this command.** `/bump-version` handles the full version bump cycle: it increments `package.json`, updates the CHANGELOG, creates the annotated tag, and pushes master + the tag to origin.
+
+`/npm-release` only pushes the tag to the public remote and monitors the publish CI workflow.
+
+---
+
 ## Outline
 
-You are releasing the npm package for this project. Follow these steps exactly.
+You are publishing the already-tagged version of this project to npm. Follow these steps exactly.
 
 ---
 
@@ -34,45 +42,26 @@ Do not proceed past this step unless the branch is exactly `master`.
 
 ---
 
-### Step 1 — Commit the package.json version bump
+### Step 1 — Verify the tag exists
 
-Check whether `package.json` has uncommitted changes:
-
-```bash
-git diff --name-only
-git diff --cached --name-only
-```
-
-If `package.json` appears in either list (unstaged or staged), commit it now:
+Read the version from `package.json`:
 
 ```bash
-git add package.json
-git commit -m "chore: bump version to v<version>
-
-Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+node -e "console.log(require('./package.json').version)"
 ```
 
-If `package.json` is clean (already committed), skip this sub-step and continue.
+The expected tag is `v<version>`. Verify it exists on origin:
 
-If `package.json` is absent from the diff but the tag for the current version already exists locally or on origin, stop and tell the user the version has already been released and they need to bump it first.
+```bash
+git ls-remote origin "refs/tags/v<version>"
+```
+
+If the tag does not exist on origin, stop and tell the user:
+"Tag v<version> has not been pushed to origin yet. Run `/bump-version` first."
 
 ---
 
-### Step 2 — Update the changelog
-
-Before tagging, invoke the `/update-changelog` skill inline (do not ask the user to run it separately — run it as part of this flow):
-
-- Read the version from `package.json`
-- Collect commits since the last tag
-- Generate and commit the changelog entry to `master` on `origin`
-
-The changelog commit must exist on `master` **before** the tag is created, so it is included in the release.
-
-If changelog generation fails for any reason, stop and report the error. Do not proceed to tagging.
-
----
-
-### Step 3 — Run the publish-npm script
+### Step 2 — Run the publish-npm script
 
 Run:
 ```bash
@@ -85,21 +74,21 @@ If it succeeds, note the tag name printed by the script (e.g. `v0.1.1`).
 
 ---
 
-### Step 4 — Locate the triggered workflow run
+### Step 3 — Locate the triggered workflow run
 
 Wait about 5 seconds for GitHub to register the tag push, then run:
 ```bash
 gh run list --repo aarthi-ntrjn/argus --workflow=publish-npm.yml --limit=5 --json databaseId,status,conclusion,headBranch,createdAt
 ```
 
-Find the run whose `headBranch` matches the tag pushed in Step 3. Note its `databaseId`.
+Find the run whose `headBranch` matches the tag pushed in Step 2. Note its `databaseId`.
 
 If no matching run appears after two attempts (10 seconds apart), report:
 "The workflow did not appear on the public repo. Check https://github.com/aarthi-ntrjn/argus/actions manually."
 
 ---
 
-### Step 5 — Poll until complete
+### Step 4 — Poll until complete
 
 Poll the run every 15 seconds using:
 ```bash
@@ -111,7 +100,7 @@ gh run view <databaseId> --repo aarthi-ntrjn/argus --json status,conclusion,jobs
 
 ---
 
-### Step 6 — Report the result
+### Step 5 — Report the result
 
 **On success** (`conclusion` is `success`):
 

--- a/.claude/commands/pull.md
+++ b/.claude/commands/pull.md
@@ -1,5 +1,5 @@
 ---
-description: Fetch the latest changes from the main branch and merge them into the current feature branch. Resolve any conflicts automatically using AI judgment.
+description: Fetch the latest changes from the parent branch and merge them into the current feature branch. Resolve any conflicts automatically using AI judgment.
 ---
 
 ## User Input
@@ -12,7 +12,7 @@ Optional. Any text supplied is treated as additional context or hints for resolv
 
 ## Outline
 
-You are a senior engineer pulling the latest changes from main into the current feature branch. Follow these steps precisely.
+You are a senior engineer pulling the latest changes from the parent branch into the current feature branch. Follow these steps precisely.
 
 ---
 
@@ -21,33 +21,35 @@ You are a senior engineer pulling the latest changes from main into the current 
 Run:
 ```
 git branch --show-current
+git rev-parse --abbrev-ref @{upstream} 2>/dev/null || echo ""
 git branch --list main master
 ```
 
 Record:
 - `CURRENT_BRANCH` = current branch name
-- `MAIN_BRANCH` = whichever of `main` / `master` exists; default to `main`
+- `UPSTREAM` = the tracking upstream from `@{upstream}` (e.g. `origin/master`). Strip the remote prefix to get `PARENT_BRANCH` (e.g. `master`). If `@{upstream}` is not set, fall back to whichever of `main` / `master` exists.
+- `REMOTE` = the remote portion of the upstream (e.g. `origin`). Default to `origin` if not set.
 
-If `CURRENT_BRANCH` equals `MAIN_BRANCH`, sync the main branch with its remote instead:
+If `CURRENT_BRANCH` equals `PARENT_BRANCH`, sync the parent branch with its remote instead:
 
 ```
-git fetch origin
-git --no-pager log HEAD..origin/<MAIN_BRANCH> --oneline
+git fetch <REMOTE>
+git --no-pager log HEAD...<REMOTE>/<PARENT_BRANCH> --oneline
 ```
 
-If there are no new commits, tell the user: "Already up to date — no new commits on `<MAIN_BRANCH>`." and stop.
+If there are no new commits, tell the user: "Already up to date — no new commits on `<PARENT_BRANCH>`." and stop.
 
 Otherwise run:
 ```
-git merge --ff-only origin/<MAIN_BRANCH>
-git push origin <MAIN_BRANCH>
+git merge --ff-only <REMOTE>/<PARENT_BRANCH>
+git push <REMOTE> <PARENT_BRANCH>
 ```
 
 Then report:
 ```
 ## Pull complete
 
-- Branch: <MAIN_BRANCH> (synced)
+- Branch: <PARENT_BRANCH> (synced)
 - Commits pulled: N
 - Pushed: ✅
 ```
@@ -59,25 +61,25 @@ And stop.
 ### Step 2 — Fetch latest from remote
 
 ```
-git fetch origin
+git fetch <REMOTE>
 ```
 
-Check whether the main branch has any new commits ahead of the current branch:
+Check whether the parent branch has any new commits ahead of the current branch:
 ```
-git --no-pager log HEAD..origin/<MAIN_BRANCH> --oneline
+git --no-pager log HEAD..<REMOTE>/<PARENT_BRANCH> --oneline
 ```
 
-If there are no new commits, tell the user: "Already up to date — no new commits on `<MAIN_BRANCH>`." and stop.
+If there are no new commits, tell the user: "Already up to date — no new commits on `<PARENT_BRANCH>`." and stop.
 
-Otherwise report how many commits are incoming (e.g. "Merging 4 commits from `main`").
+Otherwise report how many commits are incoming (e.g. "Merging 4 commits from `master`").
 
 ---
 
-### Step 3 — Merge main into the current branch
+### Step 3 — Merge parent into the current branch
 
 Run:
 ```
-git merge origin/<MAIN_BRANCH> --no-edit -m "chore: merge origin/<MAIN_BRANCH> into <CURRENT_BRANCH>
+git merge <REMOTE>/<PARENT_BRANCH> --no-edit -m "chore: merge <REMOTE>/<PARENT_BRANCH> into <CURRENT_BRANCH>
 
 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
 ```
@@ -100,13 +102,13 @@ For **each** conflicting file:
    <<<<<<< HEAD
    (current branch version)
    =======
-   (incoming version from main)
-   >>>>>>> origin/<MAIN_BRANCH>
+   (incoming version from parent)
+   >>>>>>> <REMOTE>/<PARENT_BRANCH>
    ```
 
 2. Resolve using this judgment:
-   - If the conflict is in generated or config files (lock files, build output), **prefer the incoming (main) version**.
-   - If the conflict is in feature code the current branch intentionally added, **prefer the current branch version**, unless main's change is a clear improvement or bug fix.
+   - If the conflict is in generated or config files (lock files, build output), **prefer the incoming (parent) version**.
+   - If the conflict is in feature code the current branch intentionally added, **prefer the current branch version**, unless the parent's change is a clear improvement or bug fix.
    - If both sides changed the same section in compatible ways (e.g. both added imports or entries to a list), **merge both** so neither change is lost.
    - Use any user-supplied context from `$ARGUMENTS` as an override hint.
 
@@ -124,7 +126,7 @@ git -c core.editor=true merge --continue
 
 Commit the merge with:
 ```
-git commit --no-edit -m "chore: merge origin/<MAIN_BRANCH> into <CURRENT_BRANCH> (conflicts resolved)
+git commit --no-edit -m "chore: merge <REMOTE>/<PARENT_BRANCH> into <CURRENT_BRANCH> (conflicts resolved)
 
 Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
 ```
@@ -134,7 +136,7 @@ Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
 ### Step 5 — Push the updated branch
 
 ```
-git push origin <CURRENT_BRANCH>
+git push <REMOTE> <CURRENT_BRANCH>
 ```
 
 ---
@@ -147,7 +149,7 @@ Output a concise summary:
 ## Pull complete
 
 - Branch: <CURRENT_BRANCH>
-- Merged: origin/<MAIN_BRANCH>
+- Merged: <REMOTE>/<PARENT_BRANCH>
 - Commits pulled: N
 - Conflicts resolved: N files (list them) / None
 - Pushed: ✅

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.13] - 2026-04-21
+
+### Added
+
+- **Tilde path expansion**: Repository paths and folder scans now accept `~/` and `~\` notation (e.g. `~/projects`) on all platforms, expanding to the home directory automatically.
+
+### Fixed
+
+- **No-tools install guidance**: When no supported AI tools are detected, the Launch dropdown now shows an actionable panel with direct install links for Claude Code and GitHub Copilot CLI, replacing the previous generic error message.
+
+---
+
 ## [0.1.12] - 2026-04-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.12] - 2026-04-21
+
+### Fixed
+
+- **Send prompt on non-Windows**: Sending a prompt from the Argus UI now correctly submits it in Claude Code sessions running on Linux and macOS. The fix replaces a Windows-only keyboard input path with a cross-platform `pty.write('\r')` call so the enter key is always delivered.
+
+---
+
 ## [0.1.11] - 2026-04-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Your command center for Claude Code and GitHub Copilot CLI sessions. Watch every
 ## Requirements
 
 - Node.js 22 LTS
-- GitHub Copilot CLI and/or Claude Code installed
+- [GitHub Copilot CLI](https://github.com/features/copilot/cli/) and/or [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started) installed
 
 ## Getting Started
 
@@ -112,7 +112,7 @@ The button is shown for all active sessions and is disabled (greyed out) when Ar
 
 To send prompts to a session, start it through Argus.This gives Argus a direct PTY write channel to the process.
 
-The easiest way is to click the **Launch with Argus** dropdown in any repo card header and select **Launch Claude** or **Launch Copilot**.
+The easiest way is to click the **Launch with Argus** dropdown in any repo card header and select **Launch Claude** or **Launch Copilot**. If neither tool is detected on your PATH, the dropdown shows install links for [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started) and [GitHub Copilot CLI](https://github.com/features/copilot/cli/).
 
 #### Headless Environments (Codespaces, SSH, no TTY)
 

--- a/backend/src/api/routes/fs.ts
+++ b/backend/src/api/routes/fs.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { promises as fsPromises, existsSync } from 'fs';
 import { join, normalize, basename } from 'path';
+import { expandTilde } from '../../utils/path-sandbox.js';
 
 export async function findGitRepos(dirPath: string, results: Array<{ path: string; name: string }> = []): Promise<Array<{ path: string; name: string }>> {
   // If this dir is itself a git repo, add it and don't recurse into it
@@ -33,7 +34,7 @@ export async function findGitRepos(dirPath: string, results: Array<{ path: strin
 export async function fsRoutes(app: FastifyInstance) {
   app.post('/api/v1/fs/scan-folder', async (request, reply) => {
     const body = request.body as { path?: string };
-    const scanPath = body?.path ? normalize(body.path) : null;
+    const scanPath = body?.path ? normalize(expandTilde(body.path)) : null;
     if (!scanPath) {
       return reply.status(400).send({ error: 'MISSING_PATH', message: 'path is required', requestId: request.id });
     }

--- a/backend/src/api/routes/repositories.ts
+++ b/backend/src/api/routes/repositories.ts
@@ -4,6 +4,7 @@ import { randomUUID } from 'crypto';
 import { basename } from 'path';
 import { existsSync } from 'fs';
 import { join } from 'path';
+import { expandTilde } from '../../utils/path-sandbox.js';
 import {
   getRepositories,
   getRepository,
@@ -29,8 +30,9 @@ const repositoriesRoutes: FastifyPluginAsync = async (app) => {
   });
 
   app.post<{ Body: { path?: string } }>('/api/v1/repositories', async (req, reply) => {
-    const { path: repoPath } = req.body ?? {};
-    if (!repoPath) return reply.status(400).send({ error: 'MISSING_PATH', message: 'path is required', requestId: req.id });
+    const { path: rawPath } = req.body ?? {};
+    if (!rawPath) return reply.status(400).send({ error: 'MISSING_PATH', message: 'path is required', requestId: req.id });
+    const repoPath = expandTilde(rawPath);
 
     if (!existsSync(join(repoPath, '.git'))) {
       return reply.status(400).send({ error: 'NOT_GIT_REPO', message: `The selected folder is not a git repository. To add all repos inside a parent folder, select the parent with "Add Repository".`, requestId: req.id });

--- a/backend/src/api/routes/tools.ts
+++ b/backend/src/api/routes/tools.ts
@@ -34,17 +34,8 @@ function buildLaunchCmdWithCwd(tool: ToolCommand, repoPath: string, yoloMode = f
 }
 
 function isInstalled(cmd: string): boolean {
-  if (platform() === 'win32') {
-    // Use PowerShell's Get-Command so profile-defined PATH entries and
-    // aliases are resolved, unlike where.exe which only sees system PATH.
-    const result = spawnSync(
-      'powershell',
-      ['-NoProfile', '-Command', `Get-Command ${cmd} -ErrorAction SilentlyContinue`],
-      { encoding: 'utf-8', timeout: 5000 }
-    );
-    return result.status === 0 && result.stdout.trim().length > 0;
-  }
-  const result = spawnSync('which', [cmd], { encoding: 'utf-8', timeout: 3000 });
+  const checker = platform() === 'win32' ? 'where' : 'which';
+  const result = spawnSync(checker, [cmd], { encoding: 'utf-8', timeout: 3000 });
   return result.status === 0;
 }
 

--- a/backend/src/api/routes/tools.ts
+++ b/backend/src/api/routes/tools.ts
@@ -34,8 +34,17 @@ function buildLaunchCmdWithCwd(tool: ToolCommand, repoPath: string, yoloMode = f
 }
 
 function isInstalled(cmd: string): boolean {
-  const checker = platform() === 'win32' ? 'where' : 'which';
-  const result = spawnSync(checker, [cmd], { encoding: 'utf-8', timeout: 3000 });
+  if (platform() === 'win32') {
+    // Use PowerShell's Get-Command so profile-defined PATH entries and
+    // aliases are resolved, unlike where.exe which only sees system PATH.
+    const result = spawnSync(
+      'powershell',
+      ['-NoProfile', '-Command', `Get-Command ${cmd} -ErrorAction SilentlyContinue`],
+      { encoding: 'utf-8', timeout: 5000 }
+    );
+    return result.status === 0 && result.stdout.trim().length > 0;
+  }
+  const result = spawnSync('which', [cmd], { encoding: 'utf-8', timeout: 3000 });
   return result.status === 0;
 }
 

--- a/backend/src/utils/path-sandbox.ts
+++ b/backend/src/utils/path-sandbox.ts
@@ -1,4 +1,12 @@
 import { resolve, sep } from 'path';
+import { homedir } from 'os';
+
+export function expandTilde(p: string): string {
+  if (p === '~' || p.startsWith('~/') || p.startsWith('~\\')) {
+    return homedir() + p.slice(1);
+  }
+  return p;
+}
 
 export function isPathWithinBoundary(inputPath: string, allowedBoundaries: string[]): boolean {
   // On non-Windows, a path starting with a drive letter (e.g. C:\...) is not a

--- a/frontend/src/components/LaunchDropdown/LaunchDropdown.tsx
+++ b/frontend/src/components/LaunchDropdown/LaunchDropdown.tsx
@@ -108,7 +108,32 @@ export default function LaunchDropdown({ repoPath, onLaunchError }: Props) {
           {!tools ? (
             <p className="text-xs text-gray-500 px-3 py-2">Checking installed tools…</p>
           ) : !hasAny ? (
-            <p className="text-xs text-gray-500 px-3 py-2">No supported tools found on PATH</p>
+            <div className="px-3 py-2 space-y-1">
+              <p className="text-xs text-gray-700 font-medium">No supported tools installed</p>
+              <p className="text-xs text-gray-500">Install one of the following to launch a session:</p>
+              <ul className="text-xs space-y-0.5 mt-1">
+                <li>
+                  <a
+                    href="https://docs.anthropic.com/en/docs/claude-code/getting-started"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline"
+                  >
+                    Claude Code
+                  </a>
+                </li>
+                <li>
+                  <a
+                    href="https://docs.github.com/en/copilot/how-tos/copilot-individual/using-github-copilot-in-the-command-line"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-600 hover:underline"
+                  >
+                    GitHub Copilot CLI
+                  </a>
+                </li>
+              </ul>
+            </div>
           ) : (
             <>
               {tools.claude && (

--- a/frontend/src/components/LaunchDropdown/LaunchDropdown.tsx
+++ b/frontend/src/components/LaunchDropdown/LaunchDropdown.tsx
@@ -124,7 +124,7 @@ export default function LaunchDropdown({ repoPath, onLaunchError }: Props) {
                 </li>
                 <li>
                   <a
-                    href="https://docs.github.com/en/copilot/how-tos/copilot-individual/using-github-copilot-in-the-command-line"
+                    href="https://github.com/features/copilot/cli/"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-blue-600 hover:underline"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "argus-ai-hub",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "argus-ai-hub",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "MIT",
       "workspaces": [
         "backend",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "argus-ai-hub",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "argus-ai-hub",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "MIT",
       "workspaces": [
         "backend",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argus-ai-hub",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Your command center for Claude Code and GitHub Copilot CLI sessions. Watch every session live, send commands, and stop runaway agents, all from a single browser tab.",
   "license": "MIT",
   "homepage": "https://github.com/aarthi-ntrjn/argus#readme",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argus-ai-hub",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Your command center for Claude Code and GitHub Copilot CLI sessions. Watch every session live, send commands, and stop runaway agents, all from a single browser tab.",
   "license": "MIT",
   "homepage": "https://github.com/aarthi-ntrjn/argus#readme",


### PR DESCRIPTION
This sync brings tilde path expansion for repository and folder scan inputs, a more helpful 'no tools installed' experience in the LaunchDropdown with direct install links, and a new /bump-version command for the version release workflow. The README has been updated with install requirements.

## Changes

**Backend**
- Repository paths and folder scan inputs now accept ~/  and ~\ notation, expanding to the home directory on all platforms.

**Frontend**
- The LaunchDropdown now shows an actionable install panel with direct links for Claude Code and GitHub Copilot CLI when no supported AI tools are detected, replacing the previous generic error message. The Copilot CLI link has been corrected to the official landing page.

**Docs**
- README updated with install links for Claude Code and GitHub Copilot CLI in the Requirements and Launch sections.

**Scripts**
- Added /bump-version slash command for version increment, changelog update, and tag creation. Refactored /npm-release to focus only on pushing to the public remote and monitoring CI.

## Commits

- 619115d docs: update CHANGELOG for v0.1.13
- 9d5b6d4 chore: bump version to v0.1.13
- 9a85374 feat: support tilde (~) expansion in repo path and fs scan
- d40088a feat: add /bump-version command, refactor /npm-release
- 56aa7be fix(merge-gate): update README with install links for Claude Code and Copilot CLI
- a0b406f fix: update GitHub Copilot CLI install link in LaunchDropdown
- 07f34df revert: restore original where/which tool detection
- d7df318 fix: use PowerShell Get-Command on Windows to detect installed tools
- 93bd5c8 fix: improve 'no tools installed' message in LaunchDropdown with install links
- 768d3ee fix(pull): detect parent branch from upstream tracking instead of hardcoding master
- ad1b913 chore: update CHANGELOG for v0.1.12
- 19358c2 chore: bump version to v0.1.12