### PR TITLE
v1.0.2: fix npm install failure from missing postinstall script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-05-14
+
+### Fixed
+
+- **npm install failure**: The postinstall script (`fix-node-pty-helper.mjs`) was missing from the published npm package, causing `npm install -g argus-ai-hub` to fail with exit code 1. Added the script to the `files` array in `package.json`.
+
 ## [1.0.1] - 2026-05-13
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "argus-ai-hub",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "argus-ai-hub",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argus-ai-hub",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Your command center for Claude Code and GitHub Copilot CLI sessions. Watch every session live, send commands, and stop runaway agents, all from a single browser tab.",
   "license": "MIT",
   "homepage": "https://github.com/aarthi-ntrjn/argus#readme",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bin/",
     "backend/dist/",
     "frontend/dist/",
+    "scripts/fix-node-pty-helper.mjs",
     "CHANGELOG.md"
   ],
   "keywords": [


### PR DESCRIPTION
Patch release that fixes the npm global install failure. The postinstall script (fix-node-pty-helper.mjs) was not included in the published package, causing `npm install -g argus-ai-hub` to exit with code 1 on every install.

## Commits

- b1a27505 docs: update CHANGELOG for v1.0.2
- 5855d73c chore: bump version to v1.0.2
- ad48b698 fix: include postinstall script in published npm package