### PR TITLE
v1.0.5: auto-open browser on server start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2026-05-14
+
+### Added
+
+- **Auto-open browser**: Running `argus` now automatically opens the dashboard in your default browser. Use `--no-open` to skip.
+
 ## [1.0.4] - 2026-05-14
 
 ### Fixed

--- a/bin/argus.js
+++ b/bin/argus.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { exec } from 'child_process';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
@@ -11,9 +12,26 @@ if (args.includes('--version') || args.includes('-v')) {
   process.exit(0);
 }
 
+const skipOpen = args.includes('--no-open');
+
+function openBrowser(url) {
+  const cmd =
+    process.platform === 'darwin' ? 'open' :
+    process.platform === 'win32' ? 'start' : 'xdg-open';
+  exec(`${cmd} ${url}`);
+}
+
 import { startServer } from '../backend/dist/server.js';
 
-startServer().catch((err) => {
-  console.error('Failed to start Argus:', err);
-  process.exit(1);
-});
+startServer()
+  .then((app) => {
+    if (!skipOpen) {
+      const addr = app.server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 7411;
+      openBrowser(`http://localhost:${port}`);
+    }
+  })
+  .catch((err) => {
+    console.error('Failed to start Argus:', err);
+    process.exit(1);
+  });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "argus-ai-hub",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "argus-ai-hub",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argus-ai-hub",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Your command center for Claude Code and GitHub Copilot CLI sessions. Watch every session live, send commands, and stop runaway agents, all from a single browser tab.",
   "license": "MIT",
   "homepage": "https://github.com/aarthi-ntrjn/argus#readme",


### PR DESCRIPTION
Running `argus` now automatically opens the dashboard in your default browser after the server starts. Use `--no-open` to skip the auto-open behavior.

## Commits

- 426bf290 docs: update CHANGELOG for v1.0.5
- 26411982 chore: bump version to v1.0.5
- 5cea1551 feat: auto-open browser on server start