### PR TITLE
Release v1.0.8: fix Linux terminal launch and Claude path detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.8] - 2026-05-15
+
+### Fixed
+
+- **Linux terminal launch on ptyxis and other modern emulators**: The Launch action wraps the command in `bash -c` so terminals that pass `-e` directly to `execve()` (such as ptyxis, now the default `x-terminal-emulator` on Debian/Ubuntu) parse the command correctly instead of failing with "Failed to find executable".
+- **Claude detection in `~/.local/bin`**: The dashboard now finds and launches `claude` even when the backend process (e.g. started via `npx`) does not inherit `~/.local/bin` in `PATH`. The absolute path is also baked into the launch command so the spawned terminal works regardless of its own `PATH`.
+
 ## [1.0.7] - 2026-05-14
 
 ### Fixed

--- a/backend/src/api/routes/tools.ts
+++ b/backend/src/api/routes/tools.ts
@@ -77,6 +77,11 @@ function getDirectCommandPath(cmd: string): string | null {
   return existsSync(fallbackPath) ? fallbackPath : null;
 }
 
+function getClaudeLaunchArgs(): string[] | null {
+  const directClaude = getDirectCommandPath(ToolCommands.CLAUDE);
+  return directClaude ? [directClaude] : null;
+}
+
 function getCopilotLaunchArgs(): string[] | null {
   const directCopilot = getDirectCommandPath(ToolCommands.COPILOT);
   if (directCopilot) {
@@ -164,7 +169,8 @@ function openTerminalWithCommand(cmd: string): void {
 
 const toolsRoutes: FastifyPluginAsync = async (app) => {
   app.get('/api/v1/tools', async (_req, reply) => {
-    const hasClaude = isInstalled(ToolCommands.CLAUDE);
+    const claudeLaunchArgs = getClaudeLaunchArgs();
+    const hasClaude = claudeLaunchArgs !== null;
     const copilotLaunchArgs = getCopilotLaunchArgs();
     const hasCopilot = copilotLaunchArgs !== null;
     const { yoloMode } = loadConfig();
@@ -172,7 +178,9 @@ const toolsRoutes: FastifyPluginAsync = async (app) => {
       claude: hasClaude,
       copilot: hasCopilot,
       terminalAvailable: canLaunchTerminal(),
-      claudeCmd: hasClaude ? buildLaunchCmdBase(ToolCommands.CLAUDE, yoloMode) : undefined,
+      claudeCmd: hasClaude
+        ? buildLaunchCmdBase(ToolCommands.CLAUDE, yoloMode, undefined, claudeLaunchArgs)
+        : undefined,
       copilotCmd: hasCopilot
         ? buildLaunchCmdBase(ToolCommands.COPILOT, yoloMode, undefined, copilotLaunchArgs)
         : undefined,
@@ -198,7 +206,9 @@ const toolsRoutes: FastifyPluginAsync = async (app) => {
       const { yoloMode } = loadConfig();
       const ptyLaunchId = randomUUID();
       const launchArgs =
-        tool === ToolCommands.COPILOT ? (getCopilotLaunchArgs() ?? [ToolCommands.COPILOT]) : [tool];
+        tool === ToolCommands.COPILOT
+          ? (getCopilotLaunchArgs() ?? [ToolCommands.COPILOT])
+          : (getClaudeLaunchArgs() ?? [ToolCommands.CLAUDE]);
       const cmd = repoPath
         ? buildLaunchCmdWithCwd(tool, repoPath, yoloMode, ptyLaunchId, launchArgs)
         : buildLaunchCmdBase(tool, yoloMode, ptyLaunchId, launchArgs);

--- a/backend/src/api/routes/tools.ts
+++ b/backend/src/api/routes/tools.ts
@@ -148,11 +148,15 @@ function openTerminalWithCommand(cmd: string): void {
   }
 
   // Linux: try common terminal emulators in order of preference.
+  // Wrap cmd in `bash -c` so bash splits/quotes it. Modern terminals like ptyxis
+  // (often the system's x-terminal-emulator) do not shell-parse a raw -e string.
+  // `; exec bash` keeps the window open after the launched command exits.
+  const bashWrap = ['bash', '-c', `${cmd}; exec bash`];
   const terminals = [
-    { bin: 'x-terminal-emulator', args: ['-e', cmd] },
-    { bin: 'gnome-terminal', args: ['--', 'bash', '-c', `${cmd}; exec bash`] },
-    { bin: 'xterm', args: ['-e', cmd] },
-    { bin: 'konsole', args: ['--noclose', '-e', cmd] },
+    { bin: 'x-terminal-emulator', args: ['-e', ...bashWrap] },
+    { bin: 'gnome-terminal', args: ['--', ...bashWrap] },
+    { bin: 'xterm', args: ['-e', ...bashWrap] },
+    { bin: 'konsole', args: ['--noclose', '-e', ...bashWrap] },
   ];
   for (const t of terminals) {
     if (spawnSync('which', [t.bin], { encoding: 'utf-8', timeout: 2000 }).status === 0) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1575,6 +1575,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1609,6 +1610,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1643,6 +1645,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -8438,6 +8441,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8459,6 +8463,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8480,6 +8485,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8501,6 +8507,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8522,6 +8529,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8543,6 +8551,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8564,6 +8573,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8585,6 +8595,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8606,6 +8617,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8627,6 +8639,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -8648,6 +8661,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -12904,6 +12918,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12921,6 +12936,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12938,6 +12954,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12955,6 +12972,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12972,6 +12990,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12989,6 +13008,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13006,6 +13026,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13023,6 +13044,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13040,6 +13062,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13057,6 +13080,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13074,6 +13098,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13091,6 +13116,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13108,6 +13134,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13125,6 +13152,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13142,6 +13170,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13159,6 +13188,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13176,6 +13206,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13193,6 +13224,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13210,6 +13242,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13227,6 +13260,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13244,6 +13278,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13261,6 +13296,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -13278,6 +13314,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "argus-ai-hub",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "argus-ai-hub",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argus-ai-hub",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Your command center for Claude Code and GitHub Copilot CLI sessions. Watch every session live, send commands, and stop runaway agents, all from a single browser tab.",
   "license": "MIT",
   "homepage": "https://github.com/aarthi-ntrjn/argus#readme",


### PR DESCRIPTION
This patch release fixes two Linux launch regressions affecting the dashboard's "Launch session" action. The Launch dropdown now finds and starts `claude` even when the backend process does not inherit `~/.local/bin` in `PATH`, and terminal emulators like ptyxis (now the default `x-terminal-emulator` on Debian/Ubuntu) correctly parse the spawned command instead of failing with "Failed to find executable".

## Changes

### Backend

- Detect `claude` in `~/.local/bin` when the backend process (e.g. launched via `npx`) does not inherit it in `PATH`, mirroring the existing Copilot fallback. The absolute path is also baked into the launch command so the spawned terminal works regardless of its own `PATH`.
- Wrap Linux terminal launch commands in `bash -c` so modern emulators that pass `-e` directly to `execve()` (ptyxis, etc.) shell-parse the command correctly.

### Docs

- CHANGELOG entry for v1.0.8.

### Release

- Version bumped to v1.0.8.

## Commits

- 7c3692ff docs: update CHANGELOG for v1.0.8
- 06d12d01 chore: bump version to v1.0.8
- 308c9cc9 fix: wrap linux terminal launch in bash -c so cmd is shell-parsed
- 532f7e26 fix: detect claude in ~/.local/bin when not in backend PATH