### PR TITLE
Release v1.0.9: yolo mode status in Launch dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.9] - 2026-05-16
+
+### Added
+
+- **Yolo mode status in Launch dropdown**: The "Launch with Argus" dropdown now shows whether Yolo mode is ON or OFF, with a gear icon to jump directly to Settings.
+- **First-time setup hint**: The pending session placeholder card shows a helpful message about completing CLI first-time setup and trusting the folder.
+
+### Fixed
+
+- **PTY enter key timing**: Added a wait after sending the enter key to the PTY to avoid dropped input.
+
 ## [1.0.8] - 2026-05-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Toggle between **Focused** (default, noisy tool results collapsed) and **Verbose
 
 To send prompts to a session, start it through Argus.This gives Argus a direct PTY write channel to the process.
 
-Click the **Launch with Argus** dropdown in any repo card header and select **Launch Claude** or **Launch Copilot**. If neither tool is detected on your PATH, the dropdown shows install links for [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started) and [GitHub Copilot CLI](https://github.com/features/copilot/cli/).
+Click the **Launch with Argus** dropdown in any repo card header and select **Launch Claude** or **Launch Copilot**. If neither tool is detected on your PATH, the dropdown shows install links for [Claude Code](https://docs.anthropic.com/en/docs/claude-code/getting-started) and [GitHub Copilot CLI](https://github.com/features/copilot/cli/). The dropdown footer shows the current **Yolo mode** status (ON/OFF) with a settings shortcut to change it.
 
 <img src="docs/images/argus-tour2-launchwith.png" alt="Launch with Argus dropdown" height="300">
 
@@ -205,7 +205,8 @@ When **Yolo mode** is enabled, a warning dialog is shown. After confirmation:
 
 <img src="docs/images/argus-yolo-on.png" alt="Yolo Mode Enabled" height="300">
 
-This applies to sessions launched directly from the Argus UI. 
+This applies to sessions launched directly from the Argus UI.
+The current Yolo mode status is also visible in the **Launch with Argus** dropdown, with a gear icon to quickly jump to Settings.
 To disable, toggle Yolo mode off in Settings. No confirmation is required to disable.
 
 ## Auto Update

--- a/backend/src/api/routes/tools.ts
+++ b/backend/src/api/routes/tools.ts
@@ -182,6 +182,7 @@ const toolsRoutes: FastifyPluginAsync = async (app) => {
       claude: hasClaude,
       copilot: hasCopilot,
       terminalAvailable: canLaunchTerminal(),
+      yoloMode,
       claudeCmd: hasClaude
         ? buildLaunchCmdBase(ToolCommands.CLAUDE, yoloMode, undefined, claudeLaunchArgs)
         : undefined,

--- a/backend/src/config/config-loader.ts
+++ b/backend/src/config/config-loader.ts
@@ -44,7 +44,11 @@ export function loadConfig(): ArgusConfig {
   let fileConfig: Partial<ArgusConfig> = {};
   if (!existsSync(configPath)) {
     mkdirSync(configDir, { recursive: true });
-    writeFileSync(configPath, JSON.stringify(stripTransientKeys(DEFAULTS as unknown as Record<string, unknown>), null, 2), 'utf-8');
+    writeFileSync(
+      configPath,
+      JSON.stringify(stripTransientKeys(DEFAULTS as unknown as Record<string, unknown>), null, 2),
+      'utf-8',
+    );
   } else {
     try {
       fileConfig = JSON.parse(readFileSync(configPath, 'utf-8'));
@@ -56,7 +60,11 @@ export function loadConfig(): ArgusConfig {
   const raw = fileConfig as Record<string, unknown>;
   if ('integrationsEnabled' in raw) {
     delete raw.integrationsEnabled;
-    writeFileSync(configPath, JSON.stringify(stripTransientKeys({ ...DEFAULTS, ...fileConfig }), null, 2), 'utf-8');
+    writeFileSync(
+      configPath,
+      JSON.stringify(stripTransientKeys({ ...DEFAULTS, ...fileConfig }), null, 2),
+      'utf-8',
+    );
   }
 
   const config = { ...DEFAULTS, ...fileConfig };
@@ -77,5 +85,9 @@ export function saveConfig(config: ArgusConfig): void {
   } catch {
     /* use empty */
   }
-  writeFileSync(configPath, JSON.stringify(stripTransientKeys({ ...existing, ...config }), null, 2), 'utf-8');
+  writeFileSync(
+    configPath,
+    JSON.stringify(stripTransientKeys({ ...existing, ...config }), null, 2),
+    'utf-8',
+  );
 }

--- a/backend/src/launch-pty/launch.ts
+++ b/backend/src/launch-pty/launch.ts
@@ -248,6 +248,7 @@ const sendPromptInterwriteDelayV2 = async (prompt: string, skipEnter = false): P
     // Without this keyboard mimic of '\r', Windows does not recognize the end of the sentence.
     log(`pty.write enter`);
     pty.write('\r');
+    await delay(WRITE_DELAY_MS);
   } else {
     log(`pty.write enter skipped (skipEnter=true, promptLen=1)`);
   }

--- a/backend/tests/contract/tools.test.ts
+++ b/backend/tests/contract/tools.test.ts
@@ -71,5 +71,15 @@ describe('Tools API — yolo mode flag injection', () => {
         expect(res.body.copilotCmd).not.toContain('--allow-all');
       }
     });
+
+    it('exposes yoloMode boolean in the response', async () => {
+      await request.patch('/api/v1/settings').send({ yoloMode: false });
+      const off = await request.get('/api/v1/tools');
+      expect(off.body.yoloMode).toBe(false);
+
+      await request.patch('/api/v1/settings').send({ yoloMode: true });
+      const on = await request.get('/api/v1/tools');
+      expect(on.body.yoloMode).toBe(true);
+    });
   });
 });

--- a/frontend/src/components/LaunchDropdown/LaunchDropdown.tsx
+++ b/frontend/src/components/LaunchDropdown/LaunchDropdown.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Terminal, Copy, ChevronDown, Check } from 'lucide-react';
+import { Terminal, Copy, ChevronDown, Check, Settings } from 'lucide-react';
 import { ClaudeIcon, CopilotIcon } from '../SessionTypeIcon/SessionTypeIcon';
 import { getAvailableTools, launchInTerminal } from '../../services/api';
 import { Button } from '../Button';
@@ -9,6 +9,7 @@ interface Props {
   repoPath: string;
   onLaunchError: (msg: string) => void;
   onLaunchPending?: (ptyLaunchId: string, tool: 'claude' | 'copilot') => void;
+  onOpenSettings?: () => void;
 }
 
 function toLaunchErrorMessage(err: unknown): string {
@@ -19,7 +20,7 @@ function toLaunchErrorMessage(err: unknown): string {
   return `Failed to launch session: ${raw}`;
 }
 
-export default function LaunchDropdown({ repoPath, onLaunchError, onLaunchPending }: Props) {
+export default function LaunchDropdown({ repoPath, onLaunchError, onLaunchPending, onOpenSettings }: Props) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState<'claude' | 'copilot' | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -201,15 +202,30 @@ export default function LaunchDropdown({ repoPath, onLaunchError, onLaunchPendin
                 />
               )}
               <div className="border-t border-gray-100 mt-1 px-3 pt-1.5 pb-2 space-y-1">
+                <p className="text-xs text-gray-400 flex items-center gap-1">
+                  <span>
+                    Yolo mode:{' '}
+                    <span className={tools.yoloMode ? 'text-amber-700 font-medium' : ''}>
+                      {tools.yoloMode ? 'ON' : 'OFF'}
+                    </span>
+                  </span>
+                  <button
+                    type="button"
+                    className="icon-btn text-gray-400 hover:text-blue-600"
+                    title="Change in Settings"
+                    onClick={() => {
+                      setOpen(false);
+                      onOpenSettings?.();
+                    }}
+                  >
+                    <Settings size={14} aria-hidden="true" />
+                  </button>
+                </p>
                 {headless && (
                   <p className="text-[10px] text-gray-400">
                     No terminal available. Copy and run manually.
                   </p>
                 )}
-                <p className="text-[10px] text-gray-400">
-                  Log in to the CLI and trust this folder first so Argus can fully control the
-                  session.
-                </p>
               </div>
             </>
           )}

--- a/frontend/src/components/PendingSessionCard/PendingSessionCard.tsx
+++ b/frontend/src/components/PendingSessionCard/PendingSessionCard.tsx
@@ -32,6 +32,10 @@ export default function PendingSessionCard({ tool }: Props) {
         {icon}
         <span className="text-sm text-gray-500">Launching {label}…</span>
       </div>
+      <p className="text-sm text-gray-400 mt-2">
+        Complete the first-time setup in the CLI and trust this folder so Argus can fully control
+        the session.
+      </p>
     </div>
   );
 }

--- a/frontend/src/components/RepoCard/RepoCard.tsx
+++ b/frontend/src/components/RepoCard/RepoCard.tsx
@@ -22,6 +22,7 @@ interface RepoCardProps {
   onSelectSession: (id: string) => void;
   onLaunchError: (msg: string) => void;
   onLaunchPending: (ptyLaunchId: string, tool: 'claude' | 'copilot') => void;
+  onOpenSettings?: () => void;
 }
 
 export default function RepoCard({
@@ -35,6 +36,7 @@ export default function RepoCard({
   onSelectSession,
   onLaunchError,
   onLaunchPending,
+  onOpenSettings,
 }: RepoCardProps) {
   return (
     <div data-tour-id="dashboard-repo-card" className="bg-white rounded-lg shadow p-4 md:p-6">
@@ -51,6 +53,7 @@ export default function RepoCard({
               repoPath={repo.path}
               onLaunchError={onLaunchError}
               onLaunchPending={onLaunchPending}
+              onOpenSettings={onOpenSettings}
             />
             <button
               onClick={(e) => {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -391,6 +391,7 @@ export default function DashboardPage() {
             onSelectSession={handleSessionSelect}
             onLaunchError={setLaunchError}
             onLaunchPending={(id, tool) => addPending(id, repo.path, tool)}
+            onOpenSettings={() => setSettingsOpen(true)}
           />
         );
       })}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -163,6 +163,7 @@ export interface AvailableTools {
   claude: boolean;
   copilot: boolean;
   terminalAvailable: boolean;
+  yoloMode: boolean;
   claudeCmd?: string;
   copilotCmd?: string;
 }

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -13,12 +13,24 @@ if (typeof window !== 'undefined' && typeof window.localStorage.getItem !== 'fun
   function makeStorage(): Storage {
     let store: Record<string, string> = {};
     return {
-      getItem(key: string) { return key in store ? store[key] : null; },
-      setItem(key: string, value: string) { store[key] = String(value); },
-      removeItem(key: string) { delete store[key]; },
-      clear() { store = {}; },
-      key(index: number) { return Object.keys(store)[index] ?? null; },
-      get length() { return Object.keys(store).length; },
+      getItem(key: string) {
+        return key in store ? store[key] : null;
+      },
+      setItem(key: string, value: string) {
+        store[key] = String(value);
+      },
+      removeItem(key: string) {
+        delete store[key];
+      },
+      clear() {
+        store = {};
+      },
+      key(index: number) {
+        return Object.keys(store)[index] ?? null;
+      },
+      get length() {
+        return Object.keys(store).length;
+      },
     };
   }
   const ls = makeStorage();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "argus-ai-hub",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "argus-ai-hub",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argus-ai-hub",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Your command center for Claude Code and GitHub Copilot CLI sessions. Watch every session live, send commands, and stop runaway agents, all from a single browser tab.",
   "license": "MIT",
   "homepage": "https://github.com/aarthi-ntrjn/argus#readme",


### PR DESCRIPTION
v1.0.9 adds visibility of the Yolo mode setting directly in the Launch dropdown, a first-time setup hint in the pending session card, and a PTY timing fix.

## Changes

**Frontend**
- The Launch with Argus dropdown now shows Yolo mode ON/OFF status with amber highlighting
- A gear icon in the dropdown opens Settings directly for quick toggling
- The pending session placeholder shows a helpful first-time setup message

**Backend**
- The `/api/v1/tools` endpoint now includes `yoloMode` in its response

**Tests**
- Added contract test verifying the `yoloMode` field in the tools API response

**Docs**
- README updated to document the yolo status indicator in the launch dropdown
- CHANGELOG updated for v1.0.9

**Fixes**
- PTY enter key timing: added a wait after sending enter to avoid dropped input

## Commits

\`\`\`
5ba18a47 docs: update CHANGELOG for v1.0.9
9d36edbf chore: bump version to v1.0.9
15cdd656 test: add contract test for yoloMode field in tools API response
8e7f2982 docs: update README with yolo status indicator in launch dropdown
1518b282 chore(merge-gate): apply lint and format fixes
7129d716 feat: show yolo mode status in Launch dropdown and first-time setup hint in pending card
6343e422 fix: wait after PTY enter key
\`\`\`

## Commits

- 5ba18a47 docs: update CHANGELOG for v1.0.9
- 9d36edbf chore: bump version to v1.0.9
- 15cdd656 test: add contract test for yoloMode field in tools API response
- 8e7f2982 docs: update README with yolo status indicator in launch dropdown
- 1518b282 chore(merge-gate): apply lint and format fixes
- 7129d716 feat: show yolo mode status in Launch dropdown and first-time setup hint in pending card
- 6343e422 fix: wait after PTY enter key