### PR TITLE
v1.0.10: tabbed platform install on landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.10] - 2026-05-16
+
+### Added
+
+- **Tabbed install on landing page**: Platform-specific install commands (Windows/macOS vs Ubuntu with sudo) using bordered card tabs, copy icon, and auto-detection of the user's OS.
+
 ## [1.0.9] - 2026-05-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,22 +26,24 @@ Your command center for Claude Code and GitHub Copilot CLI sessions. Watch every
 
 ## Getting Started
 
-Before you start:
+**Requirements:** Node.js 22+ and npm.
 
-- Node.js and npm must be installed.
-- You must have a repository ready to clone.
-
-Run with npx (no install required):
-
-```sh
-npx argus-ai-hub
-```
-
-Or install globally so `argus-ai-hub` is always on your path:
+### Install
 
 ```sh
 npm install -g argus-ai-hub
-argus-ai-hub
+```
+
+On Ubuntu/Linux, prefix with `sudo`:
+
+```sh
+sudo npm install -g argus-ai-hub
+```
+
+### Run
+
+```sh
+argus
 ```
 
 Open **http://localhost:7411** and you're in. The port is configurable in [`~/.argus/config.json`](#storage).

--- a/landing/assets/css/styles.css
+++ b/landing/assets/css/styles.css
@@ -317,6 +317,54 @@ code {
   font-weight: 600;
 }
 
+.hero__install-wrap {
+  margin-bottom: 1.5rem;
+  max-width: 26rem;
+}
+
+.install-tabs {
+  display: inline-flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.install-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.4rem 0.75rem;
+  font-size: 0.8125rem;
+  font-family: var(--font-body);
+  font-weight: 500;
+  color: var(--color-text-muted);
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: color 0.15s, background-color 0.15s, border-color 0.15s;
+}
+
+.install-tab__pair {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.install-tab__sep {
+  opacity: 0.4;
+}
+
+.install-tab:hover {
+  color: var(--color-text);
+  border-color: var(--color-text-muted);
+}
+
+.install-tab.active {
+  color: var(--color-text);
+  border-color: var(--color-primary, #3b82f6);
+  background-color: rgba(59 130 246 / 0.05);
+}
+
 .hero__install {
   display: flex;
   align-items: center;
@@ -324,17 +372,31 @@ code {
   background-color: var(--color-code-bg);
   color: var(--color-code-text);
   border-radius: var(--radius-md);
-  padding: 0.625rem 0.75rem;
-  margin-bottom: 1.5rem;
-  max-width: 26rem;
+  padding: 0.75rem 0.75rem;
   font-family: var(--font-mono);
 }
 
-.install-command {
+.install-commands {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.install-command {
   font-size: 0.9375rem;
   color: var(--color-code-text);
   font-family: var(--font-mono);
+}
+
+.install-command--run {
+  font-size: 0.9375rem;
+  color: var(--color-code-text);
+}
+
+.install-command--run::before {
+  content: "$ ";
+  opacity: 0.5;
 }
 
 .install-copy {
@@ -342,11 +404,16 @@ code {
   border-color: transparent;
   flex-shrink: 0;
   margin-left: 0.5rem;
+  align-self: flex-start;
 }
 
 .install-copy:hover {
   background-color: rgba(255 255 255 / 0.1);
   color: #fff;
+}
+
+.install-copy.copied {
+  color: #4ade80;
 }
 
 .install-copy.copied .copy-label::before {
@@ -578,6 +645,20 @@ code {
   border-radius: var(--radius-sm);
   font-size: 0.875em;
   color: var(--color-accent);
+}
+
+.step-card__footnote {
+  margin-top: 0.75rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+  opacity: 0.75;
+}
+
+.step-card__footnote code {
+  background-color: var(--color-surface-muted);
+  padding: 0.1em 0.35em;
+  border-radius: var(--radius-sm);
+  font-size: 0.875em;
 }
 
 .privacy-pills {

--- a/landing/assets/js/main.js
+++ b/landing/assets/js/main.js
@@ -1,26 +1,91 @@
 (function () {
   'use strict';
 
-  // Clipboard copy for the install command
-  const copyBtn = document.getElementById('copy-btn');
-  if (copyBtn && navigator.clipboard) {
-    copyBtn.addEventListener('click', function () {
-      const text = copyBtn.dataset.copy;
-      navigator.clipboard.writeText(text).then(function () {
-        copyBtn.classList.add('copied');
-        setTimeout(function () {
-          copyBtn.classList.remove('copied');
-        }, 2000);
-      }).catch(function () {
-        // Silently ignore clipboard errors (permissions denied, insecure context)
+  var installCommands = {
+    default: 'npm install -g argus-ai-hub',
+    ubuntu: 'sudo npm install -g argus-ai-hub'
+  };
+
+  // Platform tabs (handles all option blocks)
+  document.querySelectorAll('.install-tabs').forEach(function (tablist) {
+    var wrap = tablist.closest('.hero__install-wrap');
+    var commandEl = wrap.querySelector('.install-command');
+    var copyBtn = wrap.querySelector('.install-copy');
+
+    tablist.querySelectorAll('.install-tab').forEach(function (tab) {
+      tab.addEventListener('click', function () {
+        tablist.querySelectorAll('.install-tab').forEach(function (t) {
+          t.classList.remove('active');
+          t.setAttribute('aria-selected', 'false');
+        });
+        tab.classList.add('active');
+        tab.setAttribute('aria-selected', 'true');
+
+        var cmd = installCommands[tab.dataset.platform];
+        if (commandEl) {
+          commandEl.textContent = cmd;
+        }
+        if (copyBtn) {
+          copyBtn.dataset.copy = cmd;
+        }
       });
     });
+  });
+
+  // Auto-detect platform and set all tab groups
+  var detectedPlatform = 'default';
+  var ua = navigator.userAgent || navigator.platform || '';
+  if (/Linux/.test(ua)) {
+    detectedPlatform = 'ubuntu';
   }
+
+  if (detectedPlatform !== 'default') {
+    document.querySelectorAll('.install-tabs').forEach(function (tablist) {
+      var wrap = tablist.closest('.hero__install-wrap');
+      var commandEl = wrap.querySelector('.install-command');
+      var copyBtn = wrap.querySelector('.install-copy');
+      var targetTab = tablist.querySelector('[data-platform="' + detectedPlatform + '"]');
+
+      if (targetTab) {
+        tablist.querySelectorAll('.install-tab').forEach(function (t) {
+          t.classList.remove('active');
+          t.setAttribute('aria-selected', 'false');
+        });
+        targetTab.classList.add('active');
+        targetTab.setAttribute('aria-selected', 'true');
+
+        var cmd = installCommands[detectedPlatform];
+        if (commandEl) {
+          commandEl.textContent = cmd;
+        }
+        if (copyBtn) {
+          copyBtn.dataset.copy = cmd;
+        }
+      }
+    });
+  }
+
+  // Clipboard copy for all copy buttons
+  document.querySelectorAll('.install-copy').forEach(function (btn) {
+    if (navigator.clipboard) {
+      btn.addEventListener('click', function () {
+        var text = btn.dataset.copy;
+        navigator.clipboard.writeText(text).then(function () {
+          btn.classList.add('copied');
+          setTimeout(function () {
+            btn.classList.remove('copied');
+          }, 2000);
+        }).catch(function () {
+          // Silently ignore clipboard errors
+        });
+      });
+    }
+  });
 
   // Badge error handler: hide parent element when a badge image fails to load
   document.querySelectorAll('.badge').forEach(function (img) {
     img.addEventListener('error', function () {
-      const parent = img.parentElement;
+      var parent = img.parentElement;
       if (parent) {
         parent.style.display = 'none';
       }

--- a/landing/index.html
+++ b/landing/index.html
@@ -75,7 +75,7 @@
             macOS
           </span>
           <span class="hero__badge hero__badge--os">
-            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="13" height="13" fill="currentColor" aria-label="Ubuntu"><path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm0 4.5a2.25 2.25 0 1 1 0 4.5 2.25 2.25 0 0 1 0-4.5zM6.75 9.75a2.25 2.25 0 1 1 0 4.5 2.25 2.25 0 0 1 0-4.5zm10.5 0a2.25 2.25 0 1 1 0 4.5 2.25 2.25 0 0 1 0-4.5zM12 10.5c.78 0 1.5.3 2.03.79l3.03-1.75a6.02 6.02 0 0 0-1.19-1.24l-1.75 3.03A2.24 2.24 0 0 0 12 10.5zm-2.03.79A2.24 2.24 0 0 0 9.75 12c0 .35.08.68.22.97L6.94 14.72a6.02 6.02 0 0 0 1.19 1.24l1.75-3.03c.33.18.7.28 1.09.29l.03.03zm2.03 2.46c-.39 0-.76-.1-1.09-.29l-1.75 3.03c.38.19.78.34 1.19.44V13.8c.22-.01.43-.05.62-.12zm1.09-.29c-.33.18-.7.28-1.09.29v3.22a6.02 6.02 0 0 0 1.19-.44l-1.75-3.03c.19-.07.4-.11.62-.12l.03-.03c.39-.01.76.11 1.09.29l1.75-3.03A2.24 2.24 0 0 0 14.25 12c0-.35-.08-.68-.22-.97l1.75-3.03"/></svg>
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="13" height="13" fill="currentColor" aria-label="Ubuntu"><path d="M17.61.455a3.41 3.41 0 0 0-3.41 3.41 3.41 3.41 0 0 0 3.41 3.41 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41zM12.92.8C8.923.777 5.137 2.941 3.148 6.451a4.5 4.5 0 0 1 .26-.007 4.92 4.92 0 0 1 2.585.737A8.316 8.316 0 0 1 12.688 3.6 4.944 4.944 0 0 1 13.723.834 11.008 11.008 0 0 0 12.92.8zm9.226 4.994a4.915 4.915 0 0 1-1.918 2.246 8.36 8.36 0 0 1-.273 8.303 4.89 4.89 0 0 1 1.632 2.54 11.156 11.156 0 0 0 .559-13.089zM3.41 7.932A3.41 3.41 0 0 0 0 11.342a3.41 3.41 0 0 0 3.41 3.409 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41zm2.027 7.866a4.908 4.908 0 0 1-2.915.358 11.1 11.1 0 0 0 7.991 6.698 11.234 11.234 0 0 0 2.422.249 4.879 4.879 0 0 1-.999-2.85 8.484 8.484 0 0 1-.836-.136 8.304 8.304 0 0 1-5.663-4.32zm11.405.928a3.41 3.41 0 0 0-3.41 3.41 3.41 3.41 0 0 0 3.41 3.41 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41z"/></svg>
             Ubuntu
           </span>
         </p>
@@ -92,20 +92,36 @@
         </p>
         <p class="hero__subheadline">
           Manage <strong>Claude Code</strong> and <strong>GitHub Copilot CLI</strong> sessions
-          from a single browser tab. See what your agents are doing, stream their output live,
-          and take back control at any moment.
+          from a single browser tab. See what your agents are doing, stream their output live to Teams or Slack,
+          and stay in control from anywhere.
         </p>
-        <div class="hero__install">
-          <code class="install-command" id="install-command">npx argus-ai-hub</code>
-          <button
-            class="btn btn--ghost install-copy"
-            id="copy-btn"
-            data-testid="copy-btn"
-            data-copy="npx argus-ai-hub"
-            aria-label="Copy install command"
-          >
-            <span data-testid="copy-feedback" class="copy-label">Copy</span>
-          </button>
+        <div class="hero__install-wrap">
+          <div class="install-tabs install-tabs--bordered" role="tablist" aria-label="Choose your platform">
+            <button class="install-tab active" role="tab" aria-selected="true" data-platform="default">
+              <span class="install-tab__pair">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M0 3.449L9.75 2.1v9.451H0m10.949-9.602L24 0v11.4H10.949M0 12.6h9.75v9.451L0 20.699M10.949 12.6H24V24l-12.9-1.801"/></svg>
+                Windows
+              </span>
+              <span class="install-tab__sep">/</span>
+              <span class="install-tab__pair">
+                <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M12.152 6.896c-.948 0-2.415-1.078-3.96-1.04-2.04.027-3.91 1.183-4.961 3.014-2.117 3.675-.546 9.103 1.519 12.09 1.013 1.454 2.208 3.09 3.792 3.039 1.52-.065 2.09-.987 3.935-.987 1.831 0 2.35.987 3.96.948 1.637-.026 2.676-1.48 3.676-2.948 1.156-1.688 1.636-3.325 1.662-3.415-.039-.013-3.182-1.221-3.22-4.857-.026-3.04 2.48-4.494 2.597-4.559-1.429-2.09-3.623-2.324-4.39-2.376-2-.156-3.675 1.09-4.61 1.09zM15.53 3.83c.843-1.012 1.4-2.427 1.245-3.83-1.207.052-2.662.805-3.532 1.818-.78.896-1.454 2.338-1.273 3.714 1.338.104 2.715-.688 3.559-1.701"/></svg>
+                macOS
+              </span>
+            </button>
+            <button class="install-tab" role="tab" aria-selected="false" data-platform="ubuntu">
+              <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M17.61.455a3.41 3.41 0 0 0-3.41 3.41 3.41 3.41 0 0 0 3.41 3.41 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41zM12.92.8C8.923.777 5.137 2.941 3.148 6.451a4.5 4.5 0 0 1 .26-.007 4.92 4.92 0 0 1 2.585.737A8.316 8.316 0 0 1 12.688 3.6 4.944 4.944 0 0 1 13.723.834 11.008 11.008 0 0 0 12.92.8zm9.226 4.994a4.915 4.915 0 0 1-1.918 2.246 8.36 8.36 0 0 1-.273 8.303 4.89 4.89 0 0 1 1.632 2.54 11.156 11.156 0 0 0 .559-13.089zM3.41 7.932A3.41 3.41 0 0 0 0 11.342a3.41 3.41 0 0 0 3.41 3.409 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41zm2.027 7.866a4.908 4.908 0 0 1-2.915.358 11.1 11.1 0 0 0 7.991 6.698 11.234 11.234 0 0 0 2.422.249 4.879 4.879 0 0 1-.999-2.85 8.484 8.484 0 0 1-.836-.136 8.304 8.304 0 0 1-5.663-4.32zm11.405.928a3.41 3.41 0 0 0-3.41 3.41 3.41 3.41 0 0 0 3.41 3.41 3.41 3.41 0 0 0 3.41-3.41 3.41 3.41 0 0 0-3.41-3.41z"/></svg>
+              Ubuntu
+            </button>
+          </div>
+          <div class="hero__install">
+            <div class="install-commands">
+              <code class="install-command" id="install-command">npm install -g argus-ai-hub</code>
+              <code class="install-command install-command--run">argus</code>
+            </div>
+            <button class="btn btn--ghost install-copy" id="copy-btn" data-testid="copy-btn" data-copy="npm install -g argus-ai-hub" aria-label="Copy install command">
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+            </button>
+          </div>
         </div>
         <div class="hero__ctas">
           <a
@@ -175,7 +191,8 @@
         <div class="step-card">
           <div class="step-card__number" aria-hidden="true">1</div>
           <h3 class="step-card__title">Install</h3>
-          <p class="step-card__body">Run <code>npx argus-ai-hub</code> in any terminal. No global install needed; it starts up instantly. Requires <strong>Node.js 22+</strong>.</p>
+          <p class="step-card__body">Run <code>npm install -g argus-ai-hub</code>, then run <code>argus</code> in any terminal. Requires <strong>Node.js 22+</strong>.</p>
+          <p class="step-card__footnote">Ubuntu: <code>sudo npm install -g argus-ai-hub</code></p>
         </div>
         <div class="step-card">
           <div class="step-card__number" aria-hidden="true">2</div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "argus-ai-hub",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "argus-ai-hub",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "hasInstallScript": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "argus-ai-hub",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Your command center for Claude Code and GitHub Copilot CLI sessions. Watch every session live, send commands, and stop runaway agents, all from a single browser tab.",
   "license": "MIT",
   "homepage": "https://github.com/aarthi-ntrjn/argus#readme",


### PR DESCRIPTION
Release v1.0.10 brings platform-aware install instructions to the landing page. Users now see a tabbed UI (Windows/macOS vs Ubuntu) that auto-detects their OS and shows the correct install command, including sudo for Ubuntu. The README install section was also rewritten for clarity.

## Changes

**Landing Page**
- Added bordered-card tab switcher for install commands (Windows/macOS vs Ubuntu with sudo)
- Auto-detects visitor OS and pre-selects the matching tab
- Install block now shows two lines: install command + run command
- Copy button replaced with clipboard icon
- Updated Ubuntu icon to official Simple Icons SVG
- Hero subheadline updated to mention Teams/Slack

**Documentation**
- README "Getting Started" rewritten with clear Install/Run sections and Ubuntu sudo note
- CHANGELOG updated for v1.0.10

## Commits

```
5f5567d1 docs: update CHANGELOG for v1.0.10
0566e16f chore: bump version to v1.0.10
5acfdfae feat(landing): tabbed install with platform-specific commands
```

## Commits

- 5f5567d1 docs: update CHANGELOG for v1.0.10
- 0566e16f chore: bump version to v1.0.10
- 5acfdfae feat(landing): tabbed install with platform-specific commands